### PR TITLE
Stylev2: "Finished" Contacts + Legal, Switched to Tabbed Sections, & Added "Edit"/"View" Buttons

### DIFF
--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -7,9 +7,6 @@ function addLPSGDFields() {
   var $trGradYear = $j( "form input#fieldGradYear" ).parent().parent();
   var $trStuNum = $j( "form input#fieldStuNum" ).parent().parent();
   var $trMomHomePhone = $j( "form input#fieldMotherHomePhone" ).parent().parent();
-  var raceCodeViewBtn = '<td><button onclick="location.href=' 
-    + "'https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601'" 
-    + '" class="editButton" type="button">View</button></td>';
 
     /*================NOTES:======================================================
    -Tables are built bottom-to-top
@@ -31,7 +28,6 @@ function addLPSGDFields() {
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_Military") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_BirthCity") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable div#stateIncludeWrapper") );
-  $trRaceCode.append( raceCodeViewBtn );
   /*
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSASID") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSIMS") );
@@ -71,23 +67,8 @@ function addLPSGDFields() {
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_FirstYearEL") );
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_NCLB") );
   
-  /* Navigation Tabs */
-  var $navTabs = $j("div#LPS-GDCustomhiddentable div#demoNavTabs");
-  $j("div#content-main form").before($navTabs).appendTo($navTabs);
-  
-  /* Navbar for collapsed view */
-  var $navBar = $j("div#LPS-GDCustomhiddentable nav#demoNavBar");
-  $navTabs.before($navBar);
-  $navTabs.before( $j("div#LPS-GDCustomhiddentable div#navToggleBox") );
-  
-  /* Style Options Section */
-  var $styleOptions = $j("div#LPS-GDCustomhiddentable div#demoStyleOptions");
-  $navTabs.before($styleOptions);
-  
   /* Comment Box */
   $j("form>div.box-round:first-child").after( $j("#demoComments") );
-
-  $j( "div#LPS-GDCustomhiddentable" ).remove();
 }
 
 /*
@@ -247,11 +228,29 @@ function LPSGDRestyle() {
   //$j('<div id="ShowAll"></div>').insertBefore( $j("form div#StudentSection") );
 }
 
-/* 
-  Hide all sections except selected, reverts to tabnav form
-    - Arg(s)  : Any valid JQuery selector
-        Default = "div#StudentSection"
-    - Returns : NULL
+/*
+  -Check URL for tag and add required elements/styling
+*/
+function selectViewStyle() {
+  if(window.location.hash === '#/TabView') {
+    var $navTabs = $j("div#LPS-GDCustomhiddentable div#demoNavTabs");
+    $j("div#content-main form").before($navTabs).appendTo($navTabs);
+    /* 
+      -Section <div>s don't receive PS 'ui-tabs' classes until clicked, 
+        simulate a click on each tab when page loads then go back to
+        default tab ('#StudentSection')
+    */
+    $j("a.sectTab").click();
+    $j('a.sectTab[href="#StudentSection"]').click();
+  } else {
+    var $navBar = $j("div#LPS-GDCustomhiddentable nav#demoNavBar");
+    $j("div#content-main form").before($navBar).before( $j("div#LPS-GDCustomhiddentable div#navToggleBox") );
+    showCollapsed();
+  }
+}
+
+/*
+  -Controls navbar slide-down/up
 */
 function toggleDisplayNav() {
   /* JQuery's .css("top", "--px") wouldn't work and this did so I'm using this */
@@ -262,25 +261,16 @@ function toggleDisplayNav() {
     navToggle.style.transition = "top 0.2s ease 0.1s";
     navToggle.style.top = "50px";
     $j("a#toggleNavBar").text("\uD83E\uDC45"); // Up Arrow
+    $j("a#toggleNavBar").parent().css("background-color", "rgb(0, 75, 120)");
   } else {
     navBar.style.top= "-100px";
     navToggle.style.transition = "top 0.15s ease 0s";
-    navToggle.style.top = "0px";
+    navToggle.style.top = "0%";
     $j("a#toggleNavBar").text("\uD83E\uDC47"); // Down Arrow
+    $j("a#toggleNavBar").parent().css("background-color", "rgb(0, 102, 165)");
   }
 }
 
-function hideCollapsed() {
-  $j(".collapseHeader").remove();
-  $j("#demoNavBar").css("top", "-100px"); // If Im going this way I can probably just dynamically add/remove it instead.
-  $j("div#navToggleBox").css( {"transition":"top 0.3s ease 0s","top":"-50px"} );
-  $j("#demoNavBar").off();
-  $j("#toggleNavBar").off();
-  $j('form div[id$="Section"]').removeClass("hide").css("display", "none");
-  $j("div#demoNavTabs > ul").prop("hidden", false);
-}
-
-/* So this seems to create a copy of the whole page and place it below everything else for some reason, could be a result of bubbling on events? */
 /* Adds toggle-collapse headers to sections & activates navbar functions */
 function showCollapsed() {
   $j("form div#StudentSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Student Information</h2>');
@@ -293,7 +283,7 @@ function showCollapsed() {
   $j("form div#ContactsSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Contacts</h2>');
   $j("form div").css("display", "block");
   $j("div#demoNavTabs > ul").prop("hidden", true);
-  toggleDisplayNav();  
+  toggleDisplayNav();
    
   /* Load page with all sections collapsed */
   $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
@@ -347,63 +337,16 @@ function showCollapsed() {
     event.preventDefault();
     toggleDisplayNav();
   });
-  
-  /* Navbar - Slide Down/Up - DEPRECATED: Navbar visibility now tied to "Show All"
-  window.onscroll = function navScroll() {
-    if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-      $j("nav#demoNavBar").css("top", "0");
-    } else {
-      $j("nav#demoNavBar").css("top", "-100px");
-    }
-  };
-  */
 }
 
-/* 
-  -Run LPS customization functions
-  -Initialize event listeners
-  -Could be replaced by surrounding code in single block
-*/
 $j(document).ready(function() {
   /* Add LPS customizations to GD page then restyle page with the new elements */
   addLPSGDFields();
   LPSGDRestyle();
+  selectViewStyle();
   
-  /* ----------------Event Listeners---------------- */
-  var $viewSelect = $j("select#demoViewStyles");
-  var curSection = location.hash.replace("#/","#"); // Cut out '/' because it causes issues
-  
-  /* View Style Selection */
-  $viewSelect.on("change", function(event) {
-    switch( $viewSelect.val() ) {
-      case 'Tab':
-        hideCollapsed();
-        if( /#.*Section/.test(location.href) ) {
-          $j('div#demoNavTabs a[href="'+ curSection +'"]').click();
-        } else {
-          $j('div#demoNavTabs a[href="#StudentSection"]').click();
-        }
-        break;
-      case 'Collapse':
-        showCollapsed();
-        break;
-      default:
-        hideCollapsed();
-        break;
-    }
-  });
-  
-  /* 
-  ---------Update Sections so they get 'ui-tabs' classes-----------
-  -Section <div>s don't receive PS 'ui-tabs' classes until clicked, 
-    simulate a click on each tab when page loads then go back to
-    default tab ('#StudentSection')
-  */
-  $j("a.sectTab").click();
-  $j('a.sectTab[href="#StudentSection"]').click();
-  
-  /* Start in Collapsed View */
-  showCollapsed();
+  /* Remove hidden customization template */
+  $j( "div#LPS-GDCustomhiddentable" ).remove();
   
   /* Remove whitespace from field values, lets DOM know when they are empty for CSS */
   $j( "input" ).val(function( index, value ) { return value.trim(); });
@@ -424,8 +367,6 @@ $j(document).ready(function() {
       InstValues['RE']='Re-Engaged';
       InstValues['Other']='Other';
 });
-
-
 
 /* 
   ~ Moved down here because scrolling through it was annoying ~

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -63,10 +63,11 @@ function AddGDfields(){
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_FirstYearEL") );
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_NCLB") );
   
-  /* Nav anchors + Expand/Collapse all */
-  var stu_header = $j("div#content-main p#student_detail_header");
-  var navbar = $j("div#LPS-GDCustomhiddentable nav#demo-navbar");
-  stu_header.after(navbar);
+  /* Insert Navigation Tabs */
+  var stu_header = $j("div#content-main p#student_detail_header"); /* seems like bad practice but should work for now */
+  var navTabs = $j("div#LPS-GDCustomhiddentable div#demo-navTabs");
+  stu_header.after(navTabs);
+  navTabs.append( $j("div#content-main form") );
 
   $j( "div#LPS-GDCustomhiddentable" ).remove();
 }
@@ -198,42 +199,43 @@ function LPSGDRestyle() {
   $VarEverythingElse.addClass( "row-everythingElse" );
   
   /* Wrap Student Section */
-  $j("form tr.row-student").wrapAll('<div id="StudentSection" class="" width="100%"><div class="row" width="100%"></div></div>'); /* Starts at top */
-  $j("form div#StudentSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Student Information</h2>');
+  $j("form tr.row-student").wrapAll('<div id="StudentSection" class=""><div class="row"></div></div>'); /* Starts at top */
   /* Wrap Subsections */
-  $j("form tr.student-contactInfo:first").before('<tr class="headerrow row-student student-contactInfo" width="100%"><td colspan="2" class="bold" width="1920px">Phone & Email</td></tr>');
-  $j("form tr.student-name:first").before('<tr class="headerrow row-student student-name" width="100%"><td colspan="2" class="bold" width="1920px">Name</td></tr>'); /* Currently using static px width, should adjust to be responsive */
+  $j("form tr.student-contactInfo:first").before('<tr class="headerrow row-student student-contactInfo"><td colspan="2" class="bold" width="1920px">Phone & Email</td></tr>');
+  $j("form tr.student-name:first").before('<tr class="headerrow row-student student-name"><td colspan="2" class="bold" width="1920px">Name</td></tr>'); /* Currently using static px width, should adjust to be responsive */
   
   /* Wrap 'Everything Else' (fields exist but don't have a section) */
   $VarEverythingElse.wrapAll('<div id="EverythingElseSection" class=""><div class="row"></div></div>'); /* Stack under Student Section */
-  $j("div#EverythingElseSection").insertAfter( $j("form div#StudentSection") );
-  $j("div#EverythingElseSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Everything Else</h2>');
+  $j("form div#EverythingElseSection").insertAfter( $j("form div#StudentSection") );
+  /*
+    NOTES:
+    -Adding a header with a fixed width so that other rows will fill in table space
+    -Probably a lazy way format the page, should change later to be more dynamic
+  */
+  $j("form .row-everythingElse").children("td:nth-child(2)").attr("width", "75%");
+  $VarEverythingElse.first().before('<tr class="headerrow row-everythingElse"><td colspan="2" class="bold" width="1920px">Information</td></tr>')
   
   /* Wrap Other Section */
   $j("form tr.row-other").wrapAll('<div id="OtherSection" class=""><div class="row"></div></div>');
-  $j("div#OtherSection").insertAfter( $j("form div#StudentSection") );
-  $j("div#OtherSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Other</h2>');
+  $j("form div#OtherSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("tr.row-other:first").before('<tr class="headerrow row-other"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
+  $j("form tr.row-other:first").before('<tr class="headerrow row-other"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
   
   /* Wrap Legal Section */
   $j("form tr.row-legal").wrapAll('<div id="LegalSection" class=""><div class="row"></div></div>');
-  $j("div#LegalSection").insertAfter( $j("form div#StudentSection") );
-  $j("div#LegalSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Legal Information</h2>');
+  $j("form div#LegalSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("tr.row-legal:first").before('<tr class="headerrow row-legal"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
+  $j("form tr.row-legal:first").before('<tr class="headerrow row-legal"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
   
   /* Wrap Grad Section */
   $j("form tr.row-grad").wrapAll('<div id="GradSection" class=""><div class="row"></div></div>');
-  $j("div#GradSection").insertAfter( $j("form div#StudentSection") );
-  $j("div#GradSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Graduation Information</h2>');
+  $j("form div#GradSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("tr.row-grad:first").before('<tr class="headerrow row-grad"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
+  $j("form tr.row-grad:first").before('<tr class="headerrow row-grad"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
   
   /* Wrap Office Section*/
   $j("form tr.row-office").wrapAll('<div id="OfficeSection" class=""><div class="row"></div></div>');
   $j("form div#OfficeSection").insertAfter( $j("form div#StudentSection") );
-  $j("form div#OfficeSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Administrative Information</h2>');
   /* Wrap Subsections */
   $j("form tr.office-general:first").before('<tr class="headerrow row-office office-general"><td colspan="2" class="bold" width="1920px">District Information</td></tr>');
   $j("form tr.office-el:first").before('<tr class="headerrow row-office office-el"><td colspan="2" class="bold" width="1920px">EL Information</td></tr>');
@@ -242,7 +244,6 @@ function LPSGDRestyle() {
   /* Wrap Race Section */
   $j("form tr.row-ethRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"></div></div>');
   $j("form div#EthRaceSection").insertAfter( $j("form div#StudentSection") );
-  $j("form div#EthRaceSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Ethnicity/Race Information</h2>');
   /* Wrap Subsections */
   $j("form tr.ethrace-select:first").before('<tr class="headerrow row-ethRace ethrace-select"><td colspan="2" class="bold" width="1920px">Ethnicity & Race</td></tr>');
   $j("form tr.ethrace-other:first").before('<tr class="headerrow row-ethRace ethrace-other"><td colspan="2" class="bold" width="1920px">Other State General</td></tr>');
@@ -250,7 +251,6 @@ function LPSGDRestyle() {
   /* Wrap Contacts Section */
   $j("form tr.row-contacts").wrapAll('<div id="ContactsSection" class=""><div class="row"></div></div>');
   $j("form div#ContactsSection").insertAfter( $j("form div#StudentSection") );
-  $j("form div#ContactsSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Contacts</h2>');
   /* Wrap Subsections */
   $j("form tr.contacts-std:first").before( '<tr class="headerrow row-contacts contacts-std"> <td></td> <td class="bold">Contact 1</td> <td class="bold">Contact 2</td> </tr>');
   $j("form tr.contacts-emergency:first").before('<tr class="headerrow row-contacts contacts-emergency"> <td></td> <td class="bold">E-Contact 1</td> <td class="bold">E-Contact 2</td> </tr>');
@@ -259,10 +259,19 @@ function LPSGDRestyle() {
   $j("form tr.contacts-fatherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-fatherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Father - Old</td> </tr>');
   $j("form tr.contacts-motherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-motherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Mother - Old</td> </tr>');
   
+  /* 
+  ---------Update Sections so they get 'ui-tabs' classes---------
+  -Section <div>s don't receive PS 'ui-tabs' classes until clicked, 
+    so simulate a click on each tab when page loads then
+    click back to starting section (Students)
+  */
+  $j(".sectLink").click();
+  $j(".sectLink[href='#StudentSection']").click();
+  
   /* Remove whitespace from field values, lets DOM know when they are empty for CSS */
   $j( "input" ).val(function( index, value ) { return value.trim(); });
   
-  /* Translate DOE Codes ('fieldName_DOE###') */
+  /* Translate DOE Codes - 'fieldName_DOE###' */
   var $enrollmentStatus_012 = $j("form input#fieldEnrollmentStatus");
   var $firstYearEL_021 = $j("form input#fieldFirstYearEL");
   var $immigrantStatus_022 = $j("form input#fieldImmigrantStatus");
@@ -401,6 +410,7 @@ function LPSGDRestyle() {
       $ELStatus_026.val("Transitional Bilingual Education");
       break;
     default:
+      
       $ELStatus_026.val("No value found");
       $ELStatus_026.addClass("noValue");
       break;
@@ -498,6 +508,7 @@ function LPSGDRestyle() {
   var $includeSIMS = $j( "form input#fieldIncludeSIMS" );
   var $includeSASID = $j( "form input#fieldIncludeSASID" );
   var $entryGrade = $j( "form input#fieldEntryGrade" );
+  var $title1NCLB = $j( "form input#fieldNCLB" ); 
   
   switch( $excludeState.val() ) {
     case 'False':
@@ -546,53 +557,17 @@ function LPSGDRestyle() {
       $entryGrade.val("No value found");
       $entryGrade.addClass("noValue");
   }
-  
-  /* Navbar - Section Links */
-  $j(".sectLink").on('click', function(event) {
-    /* Check for hash(anchor link) value NOTE: this.hash returns part of URL beginning with '#' aka the id of the linked element */
-    if (this.hash !== "") {
-      event.preventDefault();
-      var sectionAnchor = this.hash;
-      
-      if ( $j(sectionAnchor).hasClass("hide") ) {
-        $j(sectionAnchor).prev().toggleClass("collapsed expanded");
-        $j(sectionAnchor).toggleClass("hide");
-      }
-      if ( $j(sectionAnchor).length < 1 ) {
-        alert("Error: Section " + sectionAnchor + " does not exist");
-        return false;
-      }
-      
-      /* Animate smooth scroll + add hash (#) to URL when done (default click behavior) */
-      $j('html, body').animate( { scrollTop: $j(sectionAnchor).offset().top },
-        800, function () { window.location.hash = sectionAnchor; }
-      );
-    }
-  });
-  /* Navbar - Expand All */
-  $j("#expandAll").on('click', function(event) {
-    $j(".sectLink").each( function(index, elmnt) {
-      var $section = $j(elmnt.hash);
-      $section.removeClass("hide");
-      $section.prev().removeClass("collapsed").addClass("expanded");
-    });
-  });
-  /* Navbar - Collapse All */
-  $j("#collapseAll").on('click', function(event) {
-    $j(".sectLink").each( function(index, elmnt) {
-      var $section = $j(elmnt.hash);
-      $section.addClass("hide");
-      $section.prev().removeClass("expanded").addClass("collapsed");
-    });
-  });
-  /* Navbar - Slide Down/Up */
-  window.onscroll = function() {
-    if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-      document.getElementById("demo-navbar").style.top = "0";
-    } else {
-      document.getElementById("demo-navbar").style.top = "-100px";
-    }
-  };
+  switch( $title1NCLB.val() ) {
+    case '00':
+      $title1NCLB.val("Does not apply")
+      break;
+    case '01':
+      $title1NCLB.val("Student transferred from underperforming school")
+      break;
+    default:
+      $title1NCLB.val("No value found")
+      $entryGrade.addClass("noValue");
+  }
   
   /* Start page with all sections collapsed */
   $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -164,43 +164,43 @@ function LPSGDRestyle() {
   $VarEverythingElse = ($VarEverythingElse).not("form tr.row-other");
   $VarEverythingElse.addClass( "row-everythingElse" );
   
+  /*
+  ISSUE: Formmatting is bad, especially on large monitors
+    IDEA: Give each section it's own table:
+    - Copy PS table w/ custom fields into 
+  */
   /* Wrap Student Section */
-  $j("form tr.row-student").wrapAll('<div id="StudentSection" class=""><div class="row"></div></div>'); /* Starts at top */
+  $j("form tr.row-student").wrapAll('<div id="StudentSection" style="margin:0"><div class="row" style="margin:0"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>'); /* Starts at top */
   /* Wrap Subsections */
   $j("form tr.student-contactInfo:first").before('<tr class="headerrow row-student student-contactInfo"><td colspan="2" class="bold" width="100%">Phone & Email</td></tr>');
-  $j("form tr.student-name:first").before('<tr class="headerrow row-student student-name"><td colspan="2" class="bold" width="100%">Name</td></tr>'); /* Currently using static px width, should adjust to be responsive */
+  $j("form tr.student-name:first").before('<tr class="headerrow row-student student-name" style="width:100%"><td colspan="2" class="bold" width="100%">Name</td></tr>');
   
   /* Wrap 'Everything Else' (fields exist but don't have a section) */
-  $VarEverythingElse.wrapAll('<div id="EverythingElseSection" class=""><div class="row"></div></div>'); /* Stack under Student Section */
+  $VarEverythingElse.wrapAll('<div id="EverythingElseSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>'); /* Stack under Student Section */
   $j("form div#EverythingElseSection").insertAfter( $j("form div#StudentSection") );
-  /*
-    NOTES:
-    -Adding a header with fixed width so other rows will fill in table space
-    -Probably a lazy way format the page, should change later to be more dynamic
-  */
   $j("form .row-everythingElse").children("td:nth-child(2)").attr("width", "75%");
   $VarEverythingElse.first().before('<tr class="headerrow row-everythingElse"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Other Section */
-  $j("form tr.row-other").wrapAll('<div id="OtherSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-other").wrapAll('<div id="OtherSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
   $j("form div#OtherSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
   $j("form tr.row-other:first").before('<tr class="headerrow row-other"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Legal Section */
-  $j("form tr.row-legal").wrapAll('<div id="LegalSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-legal").wrapAll('<div id="LegalSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
   $j("form div#LegalSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
   $j("form tr.row-legal:first").before('<tr class="headerrow row-legal"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Grad Section */
-  $j("form tr.row-grad").wrapAll('<div id="GradSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-grad").wrapAll('<div id="GradSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
   $j("form div#GradSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
   $j("form tr.row-grad:first").before('<tr class="headerrow row-grad"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Office Section*/
-  $j("form tr.row-office").wrapAll('<div id="OfficeSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-office").wrapAll('<div id="OfficeSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
   $j("form div#OfficeSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
   $j("form tr.office-general:first").before('<tr class="headerrow row-office office-general"><td colspan="2" class="bold" width="100%">District Information</td></tr>');
@@ -208,28 +208,29 @@ function LPSGDRestyle() {
   $j("form tr.office-sped:first").before('<tr class="headerrow row-office office-sped"><td colspan="2" class="bold" width="100%">SPED Information</td></tr>');
   
   /* Wrap Race Section */
-  $j("form div#stateIncludeWrapper").wrapAll('<tr class="row-ethRace ethrace-other"><td colspan="2"></td></tr>');
-  $j("form tr.row-ethRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"></div></div>');
+  $j("form div#stateIncludeWrapper").wrapAll('<tr class="row-ethRace ethrace-other" width="100%"><td colspan="2"></td></tr>');
+  $j("form tr.row-ethRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
   $j("form div#EthRaceSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
   $j("form tr.ethrace-select:first").before('<tr class="headerrow row-ethRace ethrace-select"><td colspan="2" class="bold" width="100%">Ethnicity & Race</td></tr>');
   $j("form tr.ethrace-other:first").before('<tr class="headerrow row-ethRace ethrace-other"><td colspan="2" class="bold" width="100%">Other State General</td></tr>');
   
   /* Wrap Contacts Section */
-  $j("form div#demoContactsTable").wrapAll('<tr class="row-contacts contacts-table"><td colspan="2"></td></tr>');
-  $j("form tr.row-contacts").wrapAll('<div id="ContactsSection" class=""><div class="row"></div></div>');
+  $j("form div#demoContactsTable").wrapAll('<tr class="row-contacts contacts-table" width="100%"><td colspan="2"></td></tr>');
+  $j("form tr.row-contacts").wrapAll('<div id="ContactsSection" class=""><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
   $j("form div#ContactsSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
   $j("form tr.contacts-parentsOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld"> <td colspan="2" class="bold" width="100%">Parents - Old (will be phased out)</td> </tr>');
   $j("form tr.contacts-fatherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-fatherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Father - Old</td> </tr>');
   $j("form tr.contacts-motherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-motherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Mother - Old</td> </tr>');
   
-  /* Insert showAll Section (Empty, used for anchor) ~Might just link to StudentSection instead~ */
-  //$j('<div id="ShowAll"></div>').insertBefore( $j("form div#StudentSection") );
+  /* Remove Original Table */
+  $j("form div#StudentSection").unwrap().unwrap();
+  $j("form div#StudentSection").prev("colgroup").remove();
 }
 
 /*
-  -Check URL for tag and add required elements/styling
+  -Check URL for view tag and edit accordingly
 */
 function selectViewStyle() {
   if(window.location.hash === '#/TabView') {
@@ -249,9 +250,7 @@ function selectViewStyle() {
   }
 }
 
-/*
-  -Controls navbar slide-down/up
-*/
+/* Should try to make this disappear when bar is open, reappears when mouse hovers over bar*/
 function toggleDisplayNav() {
   /* JQuery's .css("top", "--px") wouldn't work and this did so I'm using this */
   var navBar = document.getElementById("demoNavBar"); 
@@ -282,6 +281,8 @@ function showCollapsed() {
   $j("form div#EthRaceSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Ethnicity/Race Information</h2>');
   $j("form div#ContactsSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Contacts</h2>');
   $j("form div").css("display", "block");
+  $j("form div.row").parent().css("margin", "0 11px 0 11px");
+  $j("form div.row").css("margin", "0");
   $j("div#demoNavTabs > ul").prop("hidden", true);
   toggleDisplayNav();
    
@@ -309,8 +310,9 @@ function showCollapsed() {
       }
       
       /* Animate smooth scroll + add hash (#) to URL when done (default click behavior) */
-      $j('html, body').animate( { scrollTop: $sectionAnchor.offset().top },
-        600, function () { window.location.hash = $sectionAnchor.attr('id'); }
+      var scrollDest = $sectionAnchor.offset().top - 50;
+      $j('html, body').animate( { scrollTop: scrollDest},
+        600
       );
     }
   });

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -6,22 +6,22 @@ function AddGDfields(){
   var $trMomHomePhone = $j( "form input#fieldMotherHomePhone" ).parent().parent();
   /* Tables are built bottom-to-top */
   /* Insert Custom 'Student' Fields */
-  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trfieldStudent_LPSemail") );
-  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trfieldStudent_Personalemail") );
-  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trfieldStudent_Mobile") );
+  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_LPSEmail") );
+  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_PersonalEmail") );
+  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_Mobile") );
   
   /* Insert Custom 'Contacts' Fields */
-  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trfieldParents_old") );
-  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trfieldGuardians_old") );
-  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trfieldEmergencyContacts") );
-  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trfieldContacts") );
+  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_Parents_old") );
+  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_Guardians_old") );
+  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_EmergencyContacts") );
+  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_OtherContacts") );
   
   /* Insert Custom 'Ethnicity/Race' Fields */
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trselectMilitary") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trfieldBirthCity") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trcheckboxIncludeSASID") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trcheckboxIncludeSIMS") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trcheckboxExcludeState") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_Military") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_BirthCity") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSASID") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSIMS") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_ExcludeState") );
   
   /*
     Insert Custom 'Adminstrative' Fields
@@ -29,19 +29,19 @@ function AddGDfields(){
       -Tossing rows in after RaceCode, just need them in the table and don't think original placement matters too much 
       -Date fields not showing up
   */
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trselect504") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trfieldSPEDCode") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trfieldFLEPDate") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trfieldELCode") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trfieldSchoolCode") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trselectEntryGrade") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trfieldEntryDate") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_504Plan") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_SPEDCode") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_FLEPDate") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_ELCode") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_SchoolCode") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_EntryGrade") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_EntryDate") );
   
   /* Insert Custom 'Graduation' Fields */
-  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trselectGradCoreCompletion") );
-  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trselectGradPlan") );
-  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trfieldCohort") );
-  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trfieldGradDate") );
+  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_CoreCompletion") );
+  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Plan") );
+  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Cohort") );
+  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Date") );
   
   /* TODO:Insert Custom 'Legal' fields */
   
@@ -52,16 +52,16 @@ function AddGDfields(){
       -Putting 'other-lps' items after 'other-builtIn' items 
   */
   $j( "form input#fieldPrevStuId" ).parent().parent().after( $j("div#LPS-GDCustomhiddentable tr#trselectGradeLvl") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trselectTeamFlag") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trselectOriginCountry") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trselectBirthState") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trfieldTransferFrom") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trselectEnrollmentStatus") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trcheckboxIsImmigrant") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trfieldSASID") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trselectELStatus") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trcheckboxIsEL") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trselectFirstYearEL") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_TeamFlag") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_OriginCountry") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_BirthState") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_TransferFrom") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_EnrollmentStatus") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_IsImmigrant") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_SASID") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_ELStatus") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_IsEL") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_FirstYearEL") );
   
   /* Nav anchors + Expand/Collapse all */
   var stu_header = $j("div#content-main p#student_detail_header");
@@ -76,42 +76,42 @@ function LPSGDRestyle() {
   /*              
     Student Information
   -----------------Name--------------- */
-  $j( "form input#lastName" ).parent().parent().addClass( "trsectionStudent student-name" ); /*First = 003, Middle = 004, Last = 005*/
+  $j( "form input#lastName" ).parent().parent().addClass( "row-student student-name" ); /*First = 003, Middle = 004, Last = 005*/
   /* ----------Home_Address----------- */
-  $j( "form td:contains('Home Address')" ).not("td:contains('Mailing Address')").parent().addClass( "trsectionStudent student-address" );
-  //$j( "form td:contains('~[text:psx.html.admin_students.generaldemographics.home_address]')" ).not("td:contains('Mailing Address')").parent().addClass( "trsectionStudent student-address" );
+  $j( "form td:contains('Home Address')" ).not("td:contains('Mailing Address')").parent().addClass( "row-student student-address" );
+  //$j( "form td:contains('~[text:psx.html.admin_students.generaldemographics.home_address]')" ).not("td:contains('Mailing Address')").parent().addClass( "row-student student-address" );
   /*st, apt*/
-  $j( "form input#pstreet" ).parent().parent().addClass( "trsectionStudent student-address" );
-  $j( "form input#papt" ).parent().parent().addClass( "trsectionStudent student-address" );
+  $j( "form input#pstreet" ).parent().parent().addClass( "row-student student-address" );
+  $j( "form input#papt" ).parent().parent().addClass( "row-student student-address" );
   /*city, state, zip*/
-  $j( "form input#pcity" ).parent().parent().addClass( "trsectionStudent student-address" ); /* DOE014 */
-  $j( "form select#pstate" ).parent().parent().addClass( "trsectionStudent student-address" );
-  $j( "form input#pzip" ).parent().parent().addClass( "trsectionStudent student-address" ); /* DOE051 */
+  $j( "form input#pcity" ).parent().parent().addClass( "row-student student-address" ); /* DOE014 */
+  $j( "form select#pstate" ).parent().parent().addClass( "row-student student-address" );
+  $j( "form input#pzip" ).parent().parent().addClass( "row-student student-address" ); /* DOE051 */
   /*utility*/
-  $j( "form input#pgeocode" ).parent().parent().addClass( "trsectionStudent student-address" );
-  $j( "form span#validatePrimaryAddress" ).parent().parent().addClass( "trsectionStudent student-address" );
+  $j( "form input#pgeocode" ).parent().parent().addClass( "row-student student-address" );
+  $j( "form span#validatePrimaryAddress" ).parent().parent().addClass( "row-student student-address" );
   /* ---------Mailing_Address--------- */
-  $j( "form td:contains('Mailing Address -')" ).parent().addClass( "trsectionStudent student-mail" ).removeClass("student-address"); /* Gets class cause it has "Home address" in the field */
-  $j( "form td:contains('~[text:psx.html.admin_students.generaldemographics.mailing_address_]')" ).parent().addClass( "trsectionStudent student-mail" );
+  $j( "form td:contains('Mailing Address -')" ).parent().addClass( "row-student student-mail" ).removeClass("student-address"); /* Gets class cause it has "Home address" in the field */
+  $j( "form td:contains('~[text:psx.html.admin_students.generaldemographics.mailing_address_]')" ).parent().addClass( "row-student student-mail" );
   /*mail(st, apt)*/
-  $j( "form input#mstreet" ).parent().parent().addClass( "trsectionStudent student-mail" );
-  $j( "form input#mapt" ).parent().parent().addClass( "trsectionStudent student-mail" );
+  $j( "form input#mstreet" ).parent().parent().addClass( "row-student student-mail" );
+  $j( "form input#mapt" ).parent().parent().addClass( "row-student student-mail" );
   /*mail(city, mstate, zip)*/
-  $j( "form input#mcity" ).parent().parent().addClass( "trsectionStudent student-mail" );
-  $j( "form select#mstate" ).parent().parent().addClass( "trsectionStudent student-mail" );
-  $j( "form input#mzip" ).parent().parent().addClass( "trsectionStudent student-mail" );
+  $j( "form input#mcity" ).parent().parent().addClass( "row-student student-mail" );
+  $j( "form select#mstate" ).parent().parent().addClass( "row-student student-mail" );
+  $j( "form input#mzip" ).parent().parent().addClass( "row-student student-mail" );
   /*mail(utility)*/
-  $j( "form input#mgeocode" ).parent().parent().addClass( "trsectionStudent student-mail" );
-  $j( "form span#validateMailingAddress" ).parent().parent().addClass( "trsectionStudent student-mail" );
+  $j( "form input#mgeocode" ).parent().parent().addClass( "row-student student-mail" );
+  $j( "form span#validateMailingAddress" ).parent().parent().addClass( "row-student student-mail" );
   /* -----------Phone/Email----------- */
-  $j( "form input#fieldHomePhone" ).parent().parent().addClass( "trsectionStudent student-contactInfo" );
-  $j( "form tr#trfieldStudent_Mobile" ).addClass( "trsectionStudent student-contactInfo" );
-  $j( "form tr#trfieldStudent_Personalemail" ).addClass( "trsectionStudent student-contactInfo" );
-  $j( "form tr#trfieldStudent_LPSemail" ).addClass( "trsectionStudent student-contactInfo" );
+  $j( "form input#fieldHomePhone" ).parent().parent().addClass( "row-student student-contactInfo" );
+  $j( "form tr#trStudent_Mobile" ).addClass( "row-student student-contactInfo" );
+  $j( "form tr#trStudent_PersonalEmail" ).addClass( "row-student student-contactInfo" );
+  $j( "form tr#trStudent_LPSEmail" ).addClass( "row-student student-contactInfo" );
   
   /* Guardian/Contacts Information 
   -------------------------------- */
-  /*$( "input #" ).parent().parent().addClass( "trsectionContacts" )
+  /*$( "input #" ).parent().parent().addClass( "row-contacts" )
   /*
     TODO: Fields Needed
       -Contacts
@@ -121,10 +121,10 @@ function LPSGDRestyle() {
       -Original Demo Father (old)
       -Original Demo Mother (old)
   */
-  $j( "form tr#trfieldParents_old" ).addClass( "trsectionContacts contacts-parents" );
-  $j( "form tr#trfieldGuardians_old" ).addClass( "trsectionContacts contacts-guardians" );
-  $j( "form tr#trfieldEmergencyContacts" ).addClass( "trsectionContacts contacts-emergency" );
-  $j( "form tr#trfieldContacts" ).addClass( "trsectionContacts contacts-std" );
+  $j( "form tr#trContacts_Parents_old" ).addClass( "row-contacts contacts-parents" );
+  $j( "form tr#trContacts_Guardians_old" ).addClass( "row-contacts contacts-guardians" );
+  $j( "form tr#trContacts_EmergencyContacts" ).addClass( "row-contacts contacts-emergency" );
+  $j( "form tr#trContacts_OtherContacts" ).addClass( "row-contacts contacts-std" );
   
   /* Ethnicity/Race/Other State Fields
   -----------Ethnicity_&_Race---------DOE[008, 010, 029]
@@ -134,72 +134,72 @@ function LPSGDRestyle() {
       -Ethnicity & Race selections are nested in two <div> elements
         .parent() x2
   */
-  $j( "form td:contains('Federal Ethnicity and Race')" ).parent().addClass( "trsectionEthRace ethrace-select" );  /* Federal Ethnicity and Race */
-  $j( "form td:contains('Massachusetts State Information')" ).parent().addClass( "trsectionEthRace ethrace-select" );  /* Massachusetts State Information */
-  $j( "form input#radioFedEthYes" ).parent().parent().parent().parent().addClass( "trsectionEthRace ethrace-select" );  /* DOE010 (Hispanic/Latino) */
-  $j( "form input#race_A" ).parent().parent().parent().parent().addClass( "trsectionEthRace ethrace-select" ); /* DOE010 (Race) */
-  $j( "form td:contains('MA Race Code')" ).parent().addClass( "trsectionEthRace ethrace-select" ); /* DOE010 Race code (could be autoCalculated from two fields above?)  */
+  $j( "form td:contains('Federal Ethnicity and Race')" ).parent().addClass( "row-ethRace ethrace-select" );  /* Federal Ethnicity and Race */
+  $j( "form td:contains('Massachusetts State Information')" ).parent().addClass( "row-ethRace ethrace-select" );  /* Massachusetts State Information */
+  $j( "form input#radioFedEthYes" ).parent().parent().parent().parent().addClass( "row-ethRace ethrace-select" );  /* DOE010 (Hispanic/Latino) */
+  $j( "form input#race_A" ).parent().parent().parent().parent().addClass( "row-ethRace ethrace-select" ); /* DOE010 (Race) */
+  $j( "form td:contains('MA Race Code')" ).parent().addClass( "row-ethRace ethrace-select" ); /* DOE010 Race code (could be autoCalculated from two fields above?)  */
   /* -------Other_State_General------- */
-  $j( "form tr#trcheckboxExcludeState" ).addClass( "trsectionEthRace ethrace-other" );
-  $j( "form tr#trcheckboxIncludeSIMS" ).addClass( "trsectionEthRace ethrace-other" );
-  $j( "form tr#trcheckboxIncludeSASID" ).addClass( "trsectionEthRace ethrace-other" );
-  $j( "form tr#trfieldBirthCity" ).addClass( "trsectionEthRace ethrace-other" );  /* DOE008 */
-  $j( "form tr#trselectMilitary" ).addClass( "trsectionEthRace ethrace-other" );  /* DOE029 */
+  $j( "form tr#trRace_ExcludeState" ).addClass( "row-ethRace ethrace-other" );
+  $j( "form tr#trRace_IncludeSIMS" ).addClass( "row-ethRace ethrace-other" );
+  $j( "form tr#trRace_IncludeSASID" ).addClass( "row-ethRace ethrace-other" );
+  $j( "form tr#trRace_BirthCity" ).addClass( "row-ethRace ethrace-other" );  /* DOE008 */
+  $j( "form tr#trRace_Military" ).addClass( "row-ethRace ethrace-other" );  /* DOE029 */
   
   /* LPS Office Information
   --------General_Info----- */
-  $j( "form tr#trfieldEntryDate" ).addClass( "trsectionOffice office-general" );
-  $j( "form tr#trselectEntryGrade" ).addClass( "trsectionOffice office-general" ); 
-  $j( "form tr#trfieldSchoolCode" ).addClass( "trsectionOffice office-general" ); /* DOE015 */
+  $j( "form tr#trOffice_EntryDate" ).addClass( "row-office office-general" );
+  $j( "form tr#trOffice_EntryGrade" ).addClass( "row-office office-general" ); 
+  $j( "form tr#trOffice_SchoolCode" ).addClass( "row-office office-general" ); /* DOE015 */
   /* -------EL_Info-------- */
-  $j( "form tr#trfieldELCode" ).addClass( "trsectionOffice office-el" ); /* DOE027 or 24? maybe 41? */
-  $j( "form tr#trfieldFLEPDate" ).addClass( "trsectionOffice office-el" );
+  $j( "form tr#trOffice_ELCode" ).addClass( "row-office office-el" ); /* DOE027 or 24? maybe 41? */
+  $j( "form tr#trOffice_FLEPDate" ).addClass( "row-office office-el" );
   /* ------SPED_Info------- */
-  $j( "form tr#trfieldSPEDCode" ).addClass( "trsectionOffice office-sped" ); /* DOE032, 34, 36, 38, or 40? */
-  $j( "form tr#trselect504" ).addClass( "trsectionOffice office-sped" ); /* DOE039 */
+  $j( "form tr#trOffice_SPEDCode" ).addClass( "row-office office-sped" ); /* DOE032, 34, 36, 38, or 40? */
+  $j( "form tr#trOffice_504Plan" ).addClass( "row-office office-sped" ); /* DOE039 */
   
   /* LPS Graduation
   --------Info----- */
-  $j( "form input#fieldGradYear" ).parent().parent().addClass( "trsectionGrad" );
-  $j( "form tr#trselectGradCoreCompletion" ).addClass( "trsectionGrad" ); /* DOE037 */
-  $j( "form tr#trselectGradPlan" ).addClass( "trsectionGrad" ); /* DOE033 */
-  $j( "form tr#trfieldCohort" ).addClass( "trsectionGrad" );
-  $j( "form tr#trfieldGradDate" ).addClass( "trsectionGrad" );
+  $j( "form input#Grad_Year" ).parent().parent().addClass( "row-grad" );
+  $j( "form tr#trGrad_CoreCompletion" ).addClass( "row-grad" ); /* DOE037 */
+  $j( "form tr#trGrad_Plan" ).addClass( "row-grad" ); /* DOE033 */
+  $j( "form tr#trGrad_Cohort" ).addClass( "row-grad" );
+  $j( "form tr#trGrad_Date" ).addClass( "row-grad" );
   
   /* Legal Information
   ------Name/Gender------ */
   /*legal name*/
-  $j("input#legalLastName").parent().parent().addClass( "trsectionLegal" );
-  $j("input#legalFirstName").parent().parent().addClass( "trsectionLegal" );
-  $j("input#legalMiddleName").parent().parent().addClass( "trsectionLegal" );
-  $j("input#legalSuffixTextInput").parent().parent().addClass( "trsectionLegal" );
+  $j("input#legalLastName").parent().parent().addClass( "row-legal" );
+  $j("input#legalFirstName").parent().parent().addClass( "row-legal" );
+  $j("input#legalMiddleName").parent().parent().addClass( "row-legal" );
+  $j("input#legalSuffixTextInput").parent().parent().addClass( "row-legal" );
   /*legal gender*/
-  $j("select#legalGenderSelect").parent().parent().addClass( "trsectionLegal" );  /* DOE009*/
+  $j("select#legalGenderSelect").parent().parent().addClass( "row-legal" );  /* DOE009*/
   
   /* Other-Unused(Builtin)
   -----------Info--------- */
-  $j( "form input#fieldArea" ).parent().parent().addClass( "trsectionOther other-builtIn" );
-  $j( "form input#fieldGuardianship" ).parent().parent().addClass( "trsectionOther other-builtIn" );
-  $j( "form input#fieldSSN" ).parent().parent().addClass( "trsectionOther other-builtIn" );
-  $j( "form input#fieldStuNum" ).parent().parent().addClass( "trsectionOther other-builtIn" );  /* DOE001 */
-  $j( "form input#fieldPrevStuId" ).parent().parent().addClass( "trsectionOther other-builtIn" );
-  $j( "form tr#trselectGradeLvl" ).addClass( "trsectionOther other-builtIn" );  /* DOE016 */
-  $j( "form input#fieldGuardianEmail" ).parent().parent().addClass( "trsectionOther other-builtIn" );
-  $j( "form select#primaryethnicity" ).parent().parent().addClass( "trsectionOther other-builtIn" );
+  $j( "form input#fieldArea" ).parent().parent().addClass( "row-other other-builtIn" );
+  $j( "form input#fieldGuardianship" ).parent().parent().addClass( "row-other other-builtIn" );
+  $j( "form input#fieldSSN" ).parent().parent().addClass( "row-other other-builtIn" );
+  $j( "form input#fieldStuNum" ).parent().parent().addClass( "row-other other-builtIn" );  /* DOE001 */
+  $j( "form input#fieldPrevStuId" ).parent().parent().addClass( "row-other other-builtIn" );
+  $j( "form tr#trOther_GradeLvl" ).addClass( "row-other other-builtIn" );  /* DOE016 */
+  $j( "form input#fieldGuardianEmail" ).parent().parent().addClass( "row-other other-builtIn" );
+  $j( "form select#primaryethnicity" ).parent().parent().addClass( "row-other other-builtIn" );
   
   /* Other-Unused(LPS)
   ---------Info------- */
-  /* $j( "form tr#trselectNCLB" ).addClass( "trsectionOther other-lps" ); */
-  $j( "form tr#trselectFirstYearEL" ).addClass( "trsectionOther other-lps" );  /* DOE021 */
-  $j( "form tr#trcheckboxIsEL" ).addClass( "trsectionOther other-lps" );  /* DOE025 */
-  $j( "form tr#trselectELStatus" ).addClass( "trsectionOther other-lps" );  /* DOE026 */
-  $j( "form tr#trfieldSASID" ).addClass( "trsectionOther other-lps" );  /* DOE002 */
-  $j( "form tr#trcheckboxIsImmigrant" ).addClass( "trsectionOther other-lps" );  /* DOE022 */
-  $j( "form tr#trselectEnrollmentStatus" ).addClass( "trsectionOther other-lps" );  /* DOE012 */
-  $j( "form tr#trfieldTransferFrom" ).addClass( "trsectionOther other-lps" );  
-  $j( "form tr#trselectBirthState" ).addClass( "trsectionOther other-lps" );  
-  $j( "form tr#trselectOriginCountry" ).addClass( "trsectionOther other-lps" );  /* DOE023 */
-  $j( "form tr#trselectTeamFlag" ).addClass( "trsectionOther other-lps" );
+  /* $j( "form tr#trselectNCLB" ).addClass( "row-other other-lps" ); */
+  $j( "form tr#trOther_FirstYearEL" ).addClass( "row-other other-lps" );  /* DOE021 */
+  $j( "form tr#trOther_IsEL" ).addClass( "row-other other-lps" );  /* DOE025 */
+  $j( "form tr#trOther_ELStatus" ).addClass( "row-other other-lps" );  /* DOE026 */
+  $j( "form tr#trOther_SASID" ).addClass( "row-other other-lps" );  /* DOE002 */
+  $j( "form tr#trOther_IsImmigrant" ).addClass( "row-other other-lps" );  /* DOE022 */
+  $j( "form tr#trOther_EnrollmentStatus" ).addClass( "row-other other-lps" );  /* DOE012 */
+  $j( "form tr#trOther_TransferFrom" ).addClass( "row-other other-lps" );  
+  $j( "form tr#trOther_BirthState" ).addClass( "row-other other-lps" );  
+  $j( "form tr#trOther_OriginCountry" ).addClass( "row-other other-lps" );  /* DOE023 */
+  $j( "form tr#trOther_TeamFlag" ).addClass( "row-other other-lps" );
   
   /*
     TODO: Fields Needed
@@ -208,91 +208,73 @@ function LPSGDRestyle() {
    
   /*============'EVERYTHING ELSE' Catcher============*/
   $VarEverythingElse = $j("form > div.box-round > table.linkDescList > tbody > tr");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.trsectionStudent");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.trsectionContacts");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.trsectionEthRace");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.trsectionOffice");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.trsectionGrad");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.trsectionLegal");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.trsectionOther");
-  $VarEverythingElse.addClass( "trsectionEverythingElse" );
+  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-student");
+  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-contacts");
+  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-ethRace");
+  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-office");
+  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-grad");
+  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-legal");
+  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-other");
+  $VarEverythingElse.addClass( "row-everythingElse" );
   
   /* Wrap Student Section */
-  $j("form tr.trsectionStudent").wrapAll('<div id="StudentSection" class=""><div class="row"></div></div>'); /* Starts at top */
+  $j("form tr.row-student").wrapAll('<div id="StudentSection" class="" width="100%"><div class="row" width="100%"></div></div>'); /* Starts at top */
   $j("form div#StudentSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Student Information</h2>');
   /* Wrap Subsections */
-  $j("form tr.student-contactInfo:first").before('<tr class="headerrow trsectionStudent student-contactInfo"><td colspan="2" class="bold">Phone & Email</td></tr>');
-  $j("form tr.student-name:first").before('<tr class="headerrow trsectionStudent student-name"><td colspan="2" class="bold">Name</td></tr>');
+  $j("form tr.student-contactInfo:first").before('<tr class="headerrow row-student student-contactInfo" width="100%"><td colspan="2" class="bold" width="1920px">Phone & Email</td></tr>');
+  $j("form tr.student-name:first").before('<tr class="headerrow row-student student-name" width="100%"><td colspan="2" class="bold" width="1920px">Name</td></tr>'); /* Currently using static px width, should adjust to be responsive */
   
-  
-  /* Backup headers
-  $j("form tr.student-name").wrapAll('<div id="student-name" class=""><div class="row"></div></div>');
-  $j("form div#student-name").before('<h2 class="toggle expanded" title="Click here to expand or collapse" style="">Name</h2>');
-  $j("form tr.student-address").wrapAll('<div id="student-address" class=""><div class="row"></div></div>');
-  $j("form div#student-address").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Home Address</h2>');
-  $j("form tr.student-mail").wrapAll('<div id="student-mail" class=""><div class="row"></div></div>');
-  $j("form div#student-mail").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Mailing Address</h2>');
-  $j("form tr.student-contactInfo").wrapAll('<div id="student-contactInfo" class=""><div class="row"></div></div>');
-  $j("form div#student-contactInfo").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Phone & Email</h2>');
-  */
-  /* 
-    Home address row still shows up twice at bottom, don't know how they work.
-      Possible Solution: Remove 'student-address' class from headerrows and select $j( "form td.student-address:contains('Home Address')" )
-  */
-  
-  /* Wrap 'Everything Else' (fields that exist but haven't been given a proper section) */
-  $VarEverythingElse.wrapAll('<div id="EverythingElseSection" class=""><div class="row"></div></div>'); /* Build bottom-to-top */
+  /* Wrap 'Everything Else' (fields exist but don't have a section) */
+  $VarEverythingElse.wrapAll('<div id="EverythingElseSection" class=""><div class="row"></div></div>'); /* Stack under Student Section */
   $j("div#EverythingElseSection").insertAfter( $j("form div#StudentSection") );
   $j("div#EverythingElseSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Everything Else</h2>');
-  /* Wrap Subsections */
-  
   
   /* Wrap Other Section */
-  $j("form tr.trsectionOther").wrapAll('<div id="OtherSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-other").wrapAll('<div id="OtherSection" class=""><div class="row"></div></div>');
   $j("div#OtherSection").insertAfter( $j("form div#StudentSection") );
   $j("div#OtherSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Other</h2>');
   /* Wrap Subsections */
-  $j("tr.trsectionOther:first").before('<tr class="headerrow trsectionOther"><td colspan="2" class="bold">Information</td></tr>');
+  $j("tr.row-other:first").before('<tr class="headerrow row-other"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
   
   /* Wrap Legal Section */
-  $j("form tr.trsectionLegal").wrapAll('<div id="LegalSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-legal").wrapAll('<div id="LegalSection" class=""><div class="row"></div></div>');
   $j("div#LegalSection").insertAfter( $j("form div#StudentSection") );
   $j("div#LegalSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Legal Information</h2>');
   /* Wrap Subsections */
   
   /* Wrap Grad Section */
-  $j("form tr.trsectionGrad").wrapAll('<div id="GradSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-grad").wrapAll('<div id="GradSection" class=""><div class="row"></div></div>');
   $j("div#GradSection").insertAfter( $j("form div#StudentSection") );
   $j("div#GradSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Graduation Information</h2>');
   /* Wrap Subsections */
-  $j("tr.trsectionGrad:first").before('<tr class="headerrow trsectionGrad"><td colspan="2" class="bold">Information</td></tr>');
+  $j("tr.row-grad:first").before('<tr class="headerrow row-grad"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
   
   /* Wrap Office Section*/
-  $j("form tr.trsectionOffice").wrapAll('<div id="OfficeSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-office").wrapAll('<div id="OfficeSection" class=""><div class="row"></div></div>');
   $j("form div#OfficeSection").insertAfter( $j("form div#StudentSection") );
   $j("form div#OfficeSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Administrative Information</h2>');
   /* Wrap Subsections */
-  $j("form tr.office-general:first").before('<tr class="headerrow trsectionOffice office-general"><td colspan="2" class="bold">District Information</td></tr>');
-  $j("form tr.office-el:first").before('<tr class="headerrow trsectionOffice office-el"><td colspan="2" class="bold">EL Information</td></tr>');
-  $j("form tr.office-sped:first").before('<tr class="headerrow trsectionOffice office-sped"><td colspan="2" class="bold">SPED Information</td></tr>');
+  $j("form tr.office-general:first").before('<tr class="headerrow row-office office-general"><td colspan="2" class="bold" width="1920px">District Information</td></tr>');
+  $j("form tr.office-el:first").before('<tr class="headerrow row-office office-el"><td colspan="2" class="bold" width="1920px">EL Information</td></tr>');
+  $j("form tr.office-sped:first").before('<tr class="headerrow row-office office-sped"><td colspan="2" class="bold" width="1920px">SPED Information</td></tr>');
   
   /* Wrap Race Section */
-  $j("form tr.trsectionEthRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-ethRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"></div></div>');
   $j("form div#EthRaceSection").insertAfter( $j("form div#StudentSection") );
   $j("form div#EthRaceSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Ethnicity/Race Information</h2>');
   /* Wrap Subsections */
-  $j("form tr.ethrace-select:first").before('<tr class="headerrow trsectionEthRace ethrace-select"><td colspan="2" class="bold">Ethnicity & Race</td></tr>');
-  $j("form tr.ethrace-other:first").before('<tr class="headerrow trsectionEthRace ethrace-other"><td colspan="2" class="bold">Other State General</td></tr>');
+  $j("form tr.ethrace-select:first").before('<tr class="headerrow row-ethRace ethrace-select"><td colspan="2" class="bold" width="1920px">Ethnicity & Race</td></tr>');
+  $j("form tr.ethrace-other:first").before('<tr class="headerrow row-ethRace ethrace-other"><td colspan="2" class="bold" width="1920px">Other State General</td></tr>');
   
   /* Wrap Contacts Section */
-  $j("form tr.trsectionContacts").wrapAll('<div id="ContactsSection" class=""><div class="row"></div></div>');
+  $j("form tr.row-contacts").wrapAll('<div id="ContactsSection" class=""><div class="row"></div></div>');
   $j("form div#ContactsSection").insertAfter( $j("form div#StudentSection") );
   $j("form div#ContactsSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Contacts</h2>');
   /* Wrap Subsections */
-  $j("form tr.contacts-std:first").before( '<tr class="headerrow trsectionContacts contacts-std"> <td></td> <td class="bold">Contact 1</td> <td class="bold">Contact 2</td> </tr>');
-  $j("form tr.contacts-emergency:first").before('<tr class="headerrow trsectionContacts contacts-emergency"> <td></td> <td class="bold">E-Contact 1</td> <td class="bold">E-Contact 2</td> </tr>');
-  $j("form tr.contacts-guardians:first").before('<tr class="headerrow trsectionContacts contacts-guardians"> <td></td> <td class="bold">Guardian 1</td> <td class="bold">Guardian 2</td> </tr>');
-  $j("form tr.contacts-parents:first").before('<tr class="headerrow trsectionContacts contacts-parents"> <td></td> <td class="bold">Father</td> <td class="bold">Mother</td> </tr>');
+  $j("form tr.contacts-std:first").before( '<tr class="headerrow row-contacts contacts-std"> <td></td> <td class="bold">Contact 1</td> <td class="bold">Contact 2</td> </tr>');
+  $j("form tr.contacts-emergency:first").before('<tr class="headerrow row-contacts contacts-emergency"> <td></td> <td class="bold">E-Contact 1</td> <td class="bold">E-Contact 2</td> </tr>');
+  $j("form tr.contacts-guardians:first").before('<tr class="headerrow row-contacts contacts-guardians"> <td></td> <td class="bold">Guardian 1</td> <td class="bold">Guardian 2</td> </tr>');
+  $j("form tr.contacts-parents:first").before('<tr class="headerrow row-contacts contacts-parents"> <td></td> <td class="bold">Father</td> <td class="bold">Mother</td> </tr>');
   
   /* Navbar - Section Links */
   $j(".sectLink").on('click', function(event) {
@@ -340,6 +322,204 @@ function LPSGDRestyle() {
       document.getElementById("demo-navbar").style.top = "-100px";
     }
   };
+  
+  /* Translate DOE Codes ('fieldName_DOE###') */
+  var $enrollmentStatus_012 = $j("form input#fieldEnrollmentStatus");
+  var $firstYearEL_021 = $j("form input#fieldFirstYearEL");
+  var $ELStatus_026 = $j("form input#fieldELStatus");
+  var $militaryStat_029 = $j("form input#fieldMilitaryStatus");
+  var $gradPlan_033 = $j("form input#fieldGradPlan");
+  var $coreCompletion_037 = $j("form input#fieldCoreCompletion");
+  var $504Plan_039 = $j("form input#field504Plan");
+  
+  switch($enrollmentStatus_012.val()) {
+    case '01':
+      $enrollmentStatus_012.val("Enrolled");
+      break;
+    case '04':
+      $enrollmentStatus_012.val("Graduate with Competency Determination");
+      break;
+    case '05':
+      $enrollmentStatus_012.val("Expelled");
+      break;
+    case '06':
+      $enrollmentStatus_012.val("Deceased");
+      break;
+    case '09':
+      $enrollmentStatus_012.val("Reached max age, did not graduate or receive a Certificate of attainment");
+      break;
+    case '10':
+      $enrollmentStatus_012.val("Certificate of Attainment");
+      break;
+    case '11':
+      $enrollmentStatus_012.val("11	Completed grade 12 and district-approved program. (District does not offer a Certificate of Attainment)");
+      break;
+    case '20':
+      $enrollmentStatus_012.val("Transferred — In state public");
+      break;
+    case '21':
+      $enrollmentStatus_012.val("Transferred — In state private");
+      break;
+    case '22':
+      $enrollmentStatus_012.val("Transferred — Out-of-State (public or private)");
+      break;
+    case '23':
+      $enrollmentStatus_012.val("Transferred — Home-school");
+      break;
+    case '24':
+      $enrollmentStatus_012.val("Transferred — Adult diploma program, leading to MA diploma");
+      break;
+    case '30':
+      $enrollmentStatus_012.val("Dropout — Enrolled in a non-diploma granting adult education or HiSET program");
+      break;
+    case '31':
+      $enrollmentStatus_012.val("Dropout — Entered Job Corps");
+      break;
+    case '32':
+      $enrollmentStatus_012.val("Dropout — Entered the military");
+      break;
+    case '33':
+      $enrollmentStatus_012.val("Dropout — Incarcerated, district no longer providing educational services");
+      break;
+    case '34':
+      $enrollmentStatus_012.val("Dropout — Left due to employment");
+      break;
+    case '35':
+      $enrollmentStatus_012.val("Dropout — Confirmed Dropout, plans unknown");
+      break;
+    case '36':
+      $enrollmentStatus_012.val("Dropout — and/or student status/location unknown");
+      break;
+    case '40':
+      $enrollmentStatus_012.val("Not enrolled but receiving special education services only");
+      break;
+    case '41':
+      $enrollmentStatus_012.val("Transferred — no longer receiving special education services only");
+      break;
+    default:
+      $enrollmentStatus_012.val("No value found");
+      break;
+  }  
+  switch($firstYearEL_021.val()) {
+    case '00':
+      $firstYearEL_021.val("Does not apply");
+      break;
+    case '01':
+      $firstYearEL_021.val("Student in first year of U.S. Schooling");
+      break;
+    case '02':
+      $firstYearEL_021.val("Student not in first year of U.S. Schooling");
+      break;
+    default:
+      $firstYearEL_021.val("No value found");
+      break;
+  }
+  switch($ELStatus_026.val()) {
+    case '00':
+      $ELStatus_026.val("Not Enrolled in EL Program");
+      break;
+    case '01':
+      $ELStatus_026.val("Sheltered English Immersion");
+      break;
+    case '02':
+      $ELStatus_026.val("Dual Language Education");
+      break;
+    case '03':
+      $ELStatus_026.val("Other Bilingual Program");
+      break;
+    case '04':
+      $ELStatus_026.val("Consented to opt out of all ELE programs offered in the district");
+      break;
+    case '05':
+      $ELStatus_026.val("Transitional Bilingual Education");
+      break;
+    default:
+      $ELStatus_026.val("No value found");
+      break;
+  }
+  switch($militaryStat_029.val()) {
+    case '00':
+      $militaryStat_029.val("Not a member of a military family");
+      break;
+    case '01':
+      $militaryStat_029.val("Yes, child of active duty member");
+      break;
+    case '02':
+      $militaryStat_029.val("Yes, child of member who was medically discharged or retired in the last year");
+      break;
+    case '03':
+      $militaryStat_029.val("Yes, child of member who perished in the line of duty in the last year");
+      break;
+    default:
+      $militaryStat_029.val("No value found");
+      break;
+  }
+  switch($gradPlan_033.val()) {
+    case '01':
+      $gradPlan_033.val("Four-Year Public College");
+      break;
+    case '02':
+      $gradPlan_033.val("Two-Year Public College");
+      break;
+    case '03':
+      $gradPlan_033.val("Four-Year Private College");
+      break;
+    case '04':
+      $gradPlan_033.val("Two-Year Private College");
+      break;
+    case '05':
+      $gradPlan_033.val("Other Post Secondary (Trade School)");
+      break;
+    case '06':
+      $gradPlan_033.val("Work");
+      break;
+    case '07':
+      $gradPlan_033.val("Military");
+      break;
+    case '08':
+      $gradPlan_033.val("Other (e.g., travel, family");
+      break;
+    case '09':
+      $gradPlan_033.val("Plans Unknown");
+      break;
+    case '10':
+      $gradPlan_033.val("Registered Apprenticeship");
+      break;
+    case '500':
+      $gradPlan_033.val("Post-Graduate Plans does not apply to this student at this time");
+      break;
+    default:
+      $gradPlan_033.val("No value found");
+      break;
+  }
+  switch($coreCompletion_037.val()) {
+    case '00':
+      $coreCompletion_037.val("Student is not a graduate");
+      break;
+    case '01':
+      $coreCompletion_037.val("Student graduated and successfully completed the Massachusetts Core Curriculum");
+      break;
+    case '02':
+      $coreCompletion_037.val("Student graduated and did not successfully complete the Massachusetts Core Curriculum");
+      break;
+    default:
+      $coreCompletion_037.val("No value found");
+      break;
+  }
+  switch($504Plan_039.val()) {
+    case '00':
+      $504Plan_039.val("Has not been on a 504 plan at all this school year");
+      break;
+    case '01':
+      $504Plan_039.val("Currently on a 504 plan");
+      break;
+    case '02':
+      $504Plan_039.val("Student is not currently on a 504 plan, but was earlier this school year");
+      break;
+    default:
+      $504Plan_039.val("No value found");
+      break;
+  }
   
   /* Start page with all sections collapsed */
   $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -250,7 +250,7 @@ function showCollapsed() {
     if(window.pageYOffset > 50){
       $j("#demoNavBar, #demoNavBar > a").css( {'display':'inline-block'} );
       $j("#demoNavBar").css( {'position':'fixed','top':'0','left':'0','width':'100%'} );
-      $j("#demoNavBar > a").css( {'width':'8%'} )
+      $j("#demoNavBar > a").css( {'width':'8%','background-color':'rgb(163, 191, 204)'} ) //MAKE THE LINKS LOOK LIKE THEY ARE INSET, IDK HOW JUST FIGURE IT OUT!
     } else {
       $j("#demoNavBar, #demoNavBar > a").css( {'display':'inline-flex','width':'auto'} );
       $j("#demoNavBar").css( {'position':'initial','top':'initial'} );

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -497,6 +497,7 @@ function LPSGDRestyle() {
   var $excludeState = $j( "form input#fieldExcludeState" );
   var $includeSIMS = $j( "form input#fieldIncludeSIMS" );
   var $includeSASID = $j( "form input#fieldIncludeSASID" );
+  var $entryGrade = $j( "form input#fieldEntryGrade" );
   
   switch( $excludeState.val() ) {
     case 'False':
@@ -533,6 +534,17 @@ function LPSGDRestyle() {
       $includeSASID.val("No value found");
       $includeSASID.addClass("noValue");
       break;
+  }
+  switch( $entryGrade.val() ) {
+    case '0':
+      $entryGrade.val("K");
+      break;
+    case '-2':
+      $entryGrade.val("PK");
+      break;
+    default:
+      $entryGrade.val("No value found");
+      $entryGrade.addClass("noValue");
   }
   
   /* Navbar - Section Links */

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -1,208 +1,125 @@
-/*
-  -Insert custom fields & elements from hidden div into Demographics page
-*/
-function addLPSGDFields() {
-  var $trHomePhone =  $j( "form input#fieldHomePhone" ).parent().parent();
-  var $trRaceCode = $j( "form td:contains('MA Race Code')" ).parent();
-  var $trGradYear = $j( "form input#fieldGradYear" ).parent().parent();
-  var $trStuNum = $j( "form input#fieldStuNum" ).parent().parent();
-  var $trMomHomePhone = $j( "form input#fieldMotherHomePhone" ).parent().parent();
+$j(document).ready(function() {
+  addLPSGDFields();
+  LPSGDRestyle();
+  selectViewStyle();
 
-    /*================NOTES:======================================================
-   -Tables are built bottom-to-top
-   -Sections of entirely custom fields are inserted after MA Race Code, just need
-      them in the table and don't think original placement matters. Race code 
-      defaults to bottom so this should avoid conflicts.
+  $j( "div#LPS-GDCustomhiddentable" ).remove(); /* Remove hidden LPSGDC templates */
+  $j( "input" ).val(function( index, value ) { return value.trim(); }); /* Remove extra whitespace from field values */
+  decodeDemoVals(); /* Translate DOE Codes - 'fieldName_DOE###' (Moved to seperate function for readability) */
+  
+  /* Event Listeners */
+  $j(window.location).on("hashchange", selectViewStyle());
+});
+
+/* Insert custom fields & comment box into Demographics page */
+function addLPSGDFields() {
+  var $trHomePhone =  $j("#fieldHomePhone").parent().parent();
+  var $trRaceCode = $j( "form td:contains('MA Race Code')" ).parent();
+  var $trGradYear = $j("#fieldGradYear").parent().parent();
+  var $trStuNum = $j("#fieldStuNum").parent().parent();
+  var $trMomHomePhone = $j("#fieldMotherHomePhone").parent().parent();
+
+  /*================NOTES:======================================================
+   -Sections of entirely custom fields are inserted after MA Race Code, need
+      them in table & don't think original placement matters. Race code
+      defaults to bottom, so this should avoid conflicts.
    -Contacts Table is wrapped in a <div>, copied from Contacts page minus 
       certain features.
   ============================================================================*/
-  /* 'Student' Fields */
-  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_LPSEmail") );
-  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_PersonalEmail") );
-  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_Mobile") );
-  
-  /* 'Contacts' Table */
-  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable div#demoContactsTable") );
-  
-  /* 'Ethnicity/Race' Fields */
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_Military") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_BirthCity") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable div#stateIncludeWrapper") );
-  /*
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSASID") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSIMS") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_ExcludeState") );  
-  */
-  
-  /* 'Adminstrative' Fields */
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_504Plan") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_SPEDCode") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_FLEPDate") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_ELCode") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_SchoolCode") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_EntryGrade") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_EntryDate") );
-  
-  /* 'Graduation' Fields */
-  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_CoreCompletion") );
-  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Plan") );
-  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Cohort") );
-  $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Date") );
-  
-  /* 'Legal' fields */
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trLegal_FullName") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trLegal_Gender") );
-  
-  /* 'Other' Fields */
-  $j( "form input#fieldPrevStuId" ).parent().parent().after( $j("div#LPS-GDCustomhiddentable tr#trselectGradeLvl") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_TeamFlag") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_OriginCountry") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_BirthState") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_TransferFrom") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_EnrollmentStatus") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_IsImmigrant") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_SASID") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_ELStatus") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_IsEL") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_FirstYearEL") );
-  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_NCLB") );
-  
-  /* Comment Box */
-  $j("form>div.box-round:first-child").after( $j("#demoComments") );
+  $trHomePhone.after( $j("#LPS-GDCustomhiddentable tr.row-student") ); /* Student          */
+  $trHomePhone.after( $j("#demoContactsTable") );                      /* Contacts         */
+  $trRaceCode.after( $j("#LPS-GDCustomhiddentable tr.row-ethRace") );  /* Ethnicity & Race */
+  $trRaceCode.after( $j("#LPS-GDCustomhiddentable tr.row-office") );   /* Adminstration    */
+  $trGradYear.after( $j("#LPS-GDCustomhiddentable tr.row-grad") );     /* Graduation       */
+  $trRaceCode.after( $j("#LPS-GDCustomhiddentable tr.row-legal") );    /* Legal            */
+  $trStuNum.after( $j("#LPS-GDCustomhiddentable tr.row-other") );      /* Other            */
+  $j("form>div.box-round:first-child").after( $j("#demoComments") );   /* Comment Box      */
+  $j("#content-main form").before( $j("#demoNavTabs") )                /* Navigation Tabs  */
+    .appendTo( $j("#demoNavTabs") );                                   /*~~~~~~~~~~~~~~~~~~*/
+  $j("div.pds-app-header-bar-center").append( $j("#demoNavBar") );     /* Navigation Bar   */
 }
 
-/*
-  -Add LPS classes to PowerSchool default fields
-  -Wrap related fields into sections and rebuild table using sections
-  -Add sub-section headers
-*/
+/* Add LPS classes to default fields & wrap class groups in section containers */
 function LPSGDRestyle() {
-  /* Student Information
+
+  const stdFieldRow = (rowSelectors, rowClassNames) => { return $j(rowSelectors).parent().parent().addClass(rowClassNames) };
+
+  /* Student
   -----------------Name--------------- */
-  $j( "form input#lastName" ).parent().parent().addClass( "row-student student-name" ); /* DOE###: First = 003, Middle = 004, Last = 005*/
+  stdFieldRow("#lastName", "row-student student-name" );
   /* ----------Home_Address----------- */
   $j( "form td:contains('Home Address')" ).not("td:contains('Mailing Address')").parent().addClass( "row-student student-address" );
-  /*st, apt*/
-  $j( "form input#pstreet" ).parent().parent().addClass( "row-student student-address" );
-  $j( "form input#papt" ).parent().parent().addClass( "row-student student-address" );
-  /*city, state, zip*/
-  $j( "form input#pcity" ).parent().parent().addClass( "row-student student-address" ); /* DOE014 */
-  $j( "form select#pstate" ).parent().parent().addClass( "row-student student-address" );
-  $j( "form input#pzip" ).parent().parent().addClass( "row-student student-address" ); /* DOE051 */
-  /*utility*/
-  $j( "form input#pgeocode" ).parent().parent().addClass( "row-student student-address" );
-  $j( "form span#validatePrimaryAddress" ).parent().parent().addClass( "row-student student-address" );
+  stdFieldRow("#pstreet, #papt, #pcity, #pstate, #pzip, #pgeocode, #validatePrimaryAddress", "row-student student-address");
   /* ---------Mailing_Address--------- */
   $j( "form td:contains('Mailing Address -')" ).parent().addClass( "row-student student-mail" ).removeClass("student-address"); /* Gets class cause it has "Home address" in the field */
   $j( "form td:contains('~[text:psx.html.admin_students.generaldemographics.mailing_address_]')" ).parent().addClass( "row-student student-mail" );
-  /*mail(st, apt)*/
-  $j( "form input#mstreet" ).parent().parent().addClass( "row-student student-mail" );
-  $j( "form input#mapt" ).parent().parent().addClass( "row-student student-mail" );
-  /*mail(city, mstate, zip)*/
-  $j( "form input#mcity" ).parent().parent().addClass( "row-student student-mail" );
-  $j( "form select#mstate" ).parent().parent().addClass( "row-student student-mail" );
-  $j( "form input#mzip" ).parent().parent().addClass( "row-student student-mail" );
-  /*mail(utility)*/
-  $j( "form input#mgeocode" ).parent().parent().addClass( "row-student student-mail" );
-  $j( "form span#validateMailingAddress" ).parent().parent().addClass( "row-student student-mail" );
+  stdFieldRow("#mstreet, #mapt, #mcity, #mstate, #mzip, #mgeocode, #validateMailingAddress", "row-student student-mail");
   /* -----------Phone/Email----------- */
-  $j( "form input#fieldHomePhone" ).parent().parent().addClass( "row-student student-contactInfo" );
-  
-  /* Guardian/Contacts Information 
-  -------------------------------- */
-  $j( "form td#father" ).parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
-  $j( "form input#fieldFatherDayPhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
-  $j( "form input#fieldFatherHomePhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
-  $j( "form input#fieldFatherEmployer" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
-  $j( "form td#mother" ).parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
-  $j( "form input#fieldMotherDayPhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
-  $j( "form input#fieldMotherHomePhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
-  $j( "form input#fieldMotherEmployer" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
-  
-  /* Ethnicity/Race/Other State Fields
-  -----------Ethnicity_&_Race--------- */
-  $j( "form td:contains('Federal Ethnicity and Race')" ).parent().addClass( "row-ethRace ethrace-select" );  /* Federal Ethnicity and Race */
-  $j( "form td:contains('Massachusetts State Information')" ).parent().addClass( "row-ethRace ethrace-select" );  /* Massachusetts State Information */
-  $j( "form input#radioFedEthYes" ).parent().parent().parent().parent().addClass( "row-ethRace ethrace-select" );  /* DOE010 (Hispanic/Latino) */
-  $j( "form input#race_A" ).parent().parent().parent().parent().addClass( "row-ethRace ethrace-select" ); /* DOE010 (Race) */
-  $j( "form td:contains('MA Race Code')" ).parent().addClass( "row-ethRace ethrace-select" ); /* DOE010 Race code */
-  
-  /* 
-    LPS Office Information
-      - Fields are initialized w/ proper classes 
-  */
+  stdFieldRow("#fieldHomePhone", "row-student student-contactInfo");
 
-  /* LPS Graduation
-  --------Info----- */
-  $j( "form input#fieldGradYear" ).parent().parent().addClass( "row-grad" );
-  
-  /* Legal Information
-  ------Name/Gender------ */
-  /* LEGAL FIELDS USING BUILT-IN | Not working (fields are made after page is loaded?) */
-  $j("form input#legalLastName").parent().parent().addClass( "row-legal" );
-  $j("form select#legalGenderSelect").parent().parent().addClass( "row-legal" );  /* DOE009*/
-  
-  /* Other-Unused(Builtin)
-  -----------Info--------- */
-  $j( "form input#fieldArea" ).parent().parent().addClass( "row-other other-builtIn" );
-  $j( "form input#fieldGuardianship" ).parent().parent().addClass( "row-other other-builtIn" );
-  $j( "form input#fieldSSN" ).parent().parent().addClass( "row-other other-builtIn" );
-  $j( "form input#fieldStuNum" ).parent().parent().addClass( "row-other other-builtIn" );  /* DOE001 */
-  $j( "form input#fieldPrevStuId" ).parent().parent().addClass( "row-other other-builtIn" );
+  /* Contacts */
+  $j( "#father" ).parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
+  stdFieldRow("form input[id^='fieldFather']", "row-contacts contacts-parentsOld contacts-fatherOld");
+  $j( "#mother" ).parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
+  stdFieldRow("form input[id^='fieldMother']", "row-contacts contacts-parentsOld contacts-motherOld");
+
+  /* Ethnicity & Race */
+  $j( "form td:contains('Federal Ethnicity and Race')" ).parent().addClass( "row-ethRace ethrace-select" );
+  $j( "form td:contains('Massachusetts State Information')" ).parent().addClass( "row-ethRace ethrace-select" );
+  $j( "#radioFedEthYes" ).parent().parent().parent().parent().addClass( "row-ethRace ethrace-select" );
+  $j( "#race_A" ).parent().parent().parent().parent().addClass( "row-ethRace ethrace-select" );
+  $j( "form td:contains('MA Race Code')" ).parent().addClass( "row-ethRace ethrace-select" );
+
+  /* Administration - All fields are initialized in LPS-GDCustomhiddentable */
+
+  /* Graduation */
+  stdFieldRow("#fieldGradYear", "row-grad");
+
+  /* Legal : USING BUILT-IN | Not working (fields are made after page is loaded?) */
+  stdFieldRow("#legalLastName, #legalGenderSelect", "row-legal");
+
+  /* Other */
+  stdFieldRow("#fieldArea, #primaryethnicity, #fieldGuardianship, #fieldPrevStuId, #fieldSSN, #fieldStuNum", "row-other other-builtIn");
   $j( "form td:contains('Grade Level')" ).parent().addClass( "row-other other-builtIn" );  /* DOE016 */
-  $j( "form input#fieldGuardianEmail" ).parent().parent().addClass( "row-other other-builtIn" );
-  $j( "form select#primaryethnicity" ).parent().parent().addClass( "row-other other-builtIn" );
    
   /*============'EVERYTHING ELSE' Catcher============*/
-  $VarEverythingElse = $j("form > div.box-round > table.linkDescList > tbody > tr");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-student");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-contacts");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-ethRace");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-office");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-grad");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-legal");
-  $VarEverythingElse = ($VarEverythingElse).not("form tr.row-other");
+  $VarEverythingElse = $j("form > div.box-round > table.linkDescList > tbody > tr").not(".row-student, .row-contacts, .row-ethrace, .row-office, .row-grad, .row-legal, row-other");
   $VarEverythingElse.addClass( "row-everythingElse" );
   
-  /*
-  ISSUE: Formmatting is bad, especially on large monitors
-    IDEA: Give each section it's own table:
-    - Copy PS table w/ custom fields into 
-  */
   /* Wrap Student Section */
   $j("form tr.row-student").wrapAll('<div id="StudentSection" style="margin:0"><div class="row" style="margin:0"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>'); /* Starts at top */
-  /* Wrap Subsections */
+  /* Subsections */
   $j("form tr.student-contactInfo:first").before('<tr class="headerrow row-student student-contactInfo"><td colspan="2" class="bold" width="100%">Phone & Email</td></tr>');
   $j("form tr.student-name:first").before('<tr class="headerrow row-student student-name" style="width:100%"><td colspan="2" class="bold" width="100%">Name</td></tr>');
   
   /* Wrap 'Everything Else' (fields exist but don't have a section) */
   $VarEverythingElse.wrapAll('<div id="EverythingElseSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>'); /* Stack under Student Section */
-  $j("form div#EverythingElseSection").insertAfter( $j("form div#StudentSection") );
+  $j("#EverythingElseSection").insertAfter( $j("#StudentSection") );
   $j("form .row-everythingElse").children("td:nth-child(2)").attr("width", "75%");
   $VarEverythingElse.first().before('<tr class="headerrow row-everythingElse"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Other Section */
   $j("form tr.row-other").wrapAll('<div id="OtherSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("form div#OtherSection").insertAfter( $j("form div#StudentSection") );
-  /* Wrap Subsections */
+  $j("#OtherSection").insertAfter( $j("form div#StudentSection") );
+  /* Subsections */
   $j("form tr.row-other:first").before('<tr class="headerrow row-other"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Legal Section */
   $j("form tr.row-legal").wrapAll('<div id="LegalSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("form div#LegalSection").insertAfter( $j("form div#StudentSection") );
-  /* Wrap Subsections */
+  $j("#LegalSection").insertAfter( $j("form div#StudentSection") );
+  /* Subsections */
   $j("form tr.row-legal:first").before('<tr class="headerrow row-legal"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Grad Section */
   $j("form tr.row-grad").wrapAll('<div id="GradSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("form div#GradSection").insertAfter( $j("form div#StudentSection") );
-  /* Wrap Subsections */
+  $j("#GradSection").insertAfter( $j("form div#StudentSection") );
+  /* Subsections */
   $j("form tr.row-grad:first").before('<tr class="headerrow row-grad"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Office Section*/
   $j("form tr.row-office").wrapAll('<div id="OfficeSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("form div#OfficeSection").insertAfter( $j("form div#StudentSection") );
-  /* Wrap Subsections */
+  $j("#OfficeSection").insertAfter( $j("form div#StudentSection") );
+  /* Subsections */
   $j("form tr.office-general:first").before('<tr class="headerrow row-office office-general"><td colspan="2" class="bold" width="100%">District Information</td></tr>');
   $j("form tr.office-el:first").before('<tr class="headerrow row-office office-el"><td colspan="2" class="bold" width="100%">EL Information</td></tr>');
   $j("form tr.office-sped:first").before('<tr class="headerrow row-office office-sped"><td colspan="2" class="bold" width="100%">SPED Information</td></tr>');
@@ -210,82 +127,79 @@ function LPSGDRestyle() {
   /* Wrap Race Section */
   $j("form div#stateIncludeWrapper").wrapAll('<tr class="row-ethRace ethrace-other" width="100%"><td colspan="2"></td></tr>');
   $j("form tr.row-ethRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("form div#EthRaceSection").insertAfter( $j("form div#StudentSection") );
-  /* Wrap Subsections */
+  $j("#EthRaceSection").insertAfter( $j("form div#StudentSection") );
+  /* Subsections */
   $j("form tr.ethrace-select:first").before('<tr class="headerrow row-ethRace ethrace-select"><td colspan="2" class="bold" width="100%">Ethnicity & Race</td></tr>');
   $j("form tr.ethrace-other:first").before('<tr class="headerrow row-ethRace ethrace-other"><td colspan="2" class="bold" width="100%">Other State General</td></tr>');
   
   /* Wrap Contacts Section */
   $j("form div#demoContactsTable").wrapAll('<tr class="row-contacts contacts-table" width="100%"><td colspan="2"></td></tr>');
   $j("form tr.row-contacts").wrapAll('<div id="ContactsSection" class=""><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("form div#ContactsSection").insertAfter( $j("form div#StudentSection") );
-  /* Wrap Subsections */
+  $j("#ContactsSection").insertAfter( $j("form div#StudentSection") );
+  /* Subsections */
   $j("form tr.contacts-parentsOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld"> <td colspan="2" class="bold" width="100%">Parents - Old (will be phased out)</td> </tr>');
   $j("form tr.contacts-fatherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-fatherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Father - Old</td> </tr>');
   $j("form tr.contacts-motherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-motherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Mother - Old</td> </tr>');
   
   /* Remove Original Table */
-  $j("form div#StudentSection").unwrap().unwrap();
-  $j("form div#StudentSection").prev("colgroup").remove();
+  $j("#StudentSection").unwrap().unwrap();
+  $j("#StudentSection").prev("colgroup").remove();
 }
 
 /*
-  -Check URL for view tag and edit accordingly
+  Check URL for view tag and edit accordingly
+    -Try using html template files to dynamically add/remove the navbar and tabs instead of hiding them?
 */
 function selectViewStyle() {
-  if(window.location.hash === '#/TabView') {
-    var $navTabs = $j("div#LPS-GDCustomhiddentable div#demoNavTabs");
-    $j("div#content-main form").before($navTabs).appendTo($navTabs);
-    /* 
-      -Section <div>s don't receive PS 'ui-tabs' classes until clicked, 
-        simulate a click on each tab when page loads then go back to
-        default tab ('#StudentSection')
-    */
-    $j("a.sectTab").click();
-    $j('a.sectTab[href="#StudentSection"]').click();
-  } else {
-    var $navBar = $j("div#LPS-GDCustomhiddentable nav#demoNavBar");
-    $j("div#content-main form").before($navBar).before( $j("div#LPS-GDCustomhiddentable div#navToggleBox") );
-    showCollapsed();
+  switch( window.location.hash.replace('#/','#') ) {
+    case "#TabView":
+      /* Remove Collapsible Headers & NavBar */
+      $j(".collapseHeader").remove();
+      $j("#demoNavBar").css("display", "none");
+      $j("#demoNavBar").off();
+      
+      /* re-enable tab display */
+      $j('form div[id$="Section"]').removeClass("hide").css("display", "none");
+      $j("#demoNavTabs > ul").prop("hidden", false);
+      
+      /*
+        -Section <div>s don't receive PS 'ui-tabs' classes until clicked, simulate click
+          on each tab when page loads then return to default ('#StudentSection')
+      */
+      $j("a.sectTab").click();
+      $j('a.sectTab[href="#StudentSection"]').click();
+      break;
+    case "#CollapseView":
+      /* Remove NavTabs */
+      $j("#demoNavTabs > ul").prop("hidden", true);
+      if( $j(".collapseHeader").length < 1 ) {
+        showCollapsed();
+      }break;
+    default:
+      window.location.hash = "CollapseView";
+      window.location.reload();
+      break;
   }
 }
 
-/* Should try to make this disappear when bar is open, reappears when mouse hovers over bar*/
-function toggleDisplayNav() {
-  /* JQuery's .css("top", "--px") wouldn't work and this did so I'm using this */
-  var navBar = document.getElementById("demoNavBar"); 
-  var navToggle = document.getElementById("navToggleBox");
-  if(navBar.style.top === "-100px") {
-    navBar.style.top = "0px";
-    navToggle.style.transition = "top 0.2s ease 0.1s";
-    navToggle.style.top = "50px";
-    $j("a#toggleNavBar").text("\uD83E\uDC45"); // Up Arrow
-    $j("a#toggleNavBar").parent().css("background-color", "rgb(0, 75, 120)");
-  } else {
-    navBar.style.top= "-100px";
-    navToggle.style.transition = "top 0.15s ease 0s";
-    navToggle.style.top = "0%";
-    $j("a#toggleNavBar").text("\uD83E\uDC47"); // Down Arrow
-    $j("a#toggleNavBar").parent().css("background-color", "rgb(0, 102, 165)");
-  }
-}
-
-/* Adds toggle-collapse headers to sections & activates navbar functions */
+/* Add toggle-collapse headers to sections & activate navbar functions */
 function showCollapsed() {
-  $j("form div#StudentSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Student Information</h2>');
-  $j("form div#EverythingElseSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Everything Else</h2>');
-  $j("form div#OtherSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Other</h2>');
-  $j("form div#LegalSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Legal Information</h2>');
-  $j("form div#GradSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Graduation Information</h2>');
-  $j("form div#OfficeSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Administrative Information</h2>');
-  $j("form div#EthRaceSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Ethnicity/Race Information</h2>');
-  $j("form div#ContactsSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Contacts</h2>');
-  $j("form div").css("display", "block");
+  
+  const createCollapseHeader = (title) => { return '<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">' + title + '</h2>' };
+  
+  $j("#StudentSection").before( createCollapseHeader("Student Information") );
+  $j("#EverythingElseSection").before( createCollapseHeader("Everything Else") );
+  $j("#OtherSection").before( createCollapseHeader("Other") );
+  $j("#LegalSection").before( createCollapseHeader("Legal Information") );
+  $j("#GradSection").before( createCollapseHeader("Graduation Information") );
+  $j("#OfficeSection").before( createCollapseHeader("Administrative Information") );
+  $j("#EthRaceSection").before( createCollapseHeader("Ethnicity/Race Information") );
+  $j("#ContactsSection").before( createCollapseHeader("Contacts") );
+  $j("form div").css("display", "box");
+  $j("#demoNavBar").css("display", "inline-flex");
   $j("form div.row").parent().css("margin", "0 11px 0 11px");
   $j("form div.row").css("margin", "0");
-  $j("div#demoNavTabs > ul").prop("hidden", true);
-  toggleDisplayNav();
-   
+
   /* Load page with all sections collapsed */
   $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
     hideCollapseClasses($j(this));
@@ -293,7 +207,7 @@ function showCollapsed() {
     hideCollapseTarget($j(this));
   });
 
-  /* Add Navbar Event Listeners */
+  /* Navbar Event Listeners */
   $j(".sectLink").on('click', function(event) {
     /* Check for hash(anchor link) value NOTE: this.hash returns part of URL beginning with '#' aka the id of the linked element */
     if (this.hash !== "") {
@@ -311,9 +225,7 @@ function showCollapsed() {
       
       /* Animate smooth scroll + add hash (#) to URL when done (default click behavior) */
       var scrollDest = $sectionAnchor.offset().top - 50;
-      $j('html, body').animate( { scrollTop: scrollDest},
-        600
-      );
+      $j('html, body').animate( { scrollTop: scrollDest}, 600);
     }
   });
   /* Navbar - Expand All */
@@ -334,56 +246,29 @@ function showCollapsed() {
       $section.prev().removeClass("expanded").addClass("collapsed");
     });
   });
-  /* Toggle NavBar On/Off */
-  $j("#toggleNavBar").on('click', function(event) {
-    event.preventDefault();
-    toggleDisplayNav();
-  });
+  $j(window).on("scroll", function(event) {
+    if(window.pageYOffset > 50){
+      $j("#demoNavBar, #demoNavBar > a").css( {'display':'inline-block'} );
+      $j("#demoNavBar").css( {'position':'fixed','top':'0','left':'0','width':'100%'} );
+      $j("#demoNavBar > a").css( {'width':'8%'} )
+    } else {
+      $j("#demoNavBar, #demoNavBar > a").css( {'display':'inline-flex','width':'auto'} );
+      $j("#demoNavBar").css( {'position':'initial','top':'initial'} );
+    }
+  })
 }
 
-$j(document).ready(function() {
-  /* Add LPS customizations to GD page then restyle page with the new elements */
-  addLPSGDFields();
-  LPSGDRestyle();
-  selectViewStyle();
-  
-  /* Remove hidden customization template */
-  $j( "div#LPS-GDCustomhiddentable" ).remove();
-  
-  /* Remove whitespace from field values, lets DOM know when they are empty for CSS */
-  $j( "input" ).val(function( index, value ) { return value.trim(); });
-  
-  /* Translate DOE Codes - 'fieldName_DOE###' (Moved to seperate function for readability) */
-  decodeDemoVals();
-
-  /* Comment codes */
-  var InstValues= {};
-      InstValues[' ']='';
-      InstValues['REG']='Registration';
-      InstValues['COA']='Change of Address';
-      InstValues['PCU']='Program Code Updates';
-      InstValues['HOME']='Homeless';
-      InstValues['TF']='TransferFrom-Original';
-      InstValues['WD']='Withdrawal';
-      InstValues['GC']='Grade Change';
-      InstValues['RE']='Re-Engaged';
-      InstValues['Other']='Other';
-});
-
-/* 
-  ~ Moved down here because scrolling through it was annoying ~
-  -Decode DOE fields + fields w/ ambiguous values
-*/
+/* Decode DOE fields + fields w/ ambiguous values */
 function decodeDemoVals() {
-  var $enrollmentStatus_012 = $j("form input#fieldEnrollmentStatus");
-  var $firstYearEL_021 = $j("form input#fieldFirstYearEL");
-  var $immigrantStatus_022 = $j("form input#fieldImmigrantStatus");
-  var $isEL_025 = $j("form input#fieldIsEL");
-  var $ELStatus_026 = $j("form input#fieldELStatus");
-  var $militaryStat_029 = $j("form input#fieldMilitaryStatus");
-  var $gradPlan_033 = $j("form input#fieldGradPlan");
-  var $coreCompletion_037 = $j("form input#fieldCoreCompletion");
-  var $504Plan_039 = $j("form input#field504Plan");
+  var $enrollmentStatus_012 = $j("#fieldEnrollmentStatus");
+  var $firstYearEL_021 = $j("#fieldFirstYearEL");
+  var $immigrantStatus_022 = $j("#fieldImmigrantStatus");
+  var $isEL_025 = $j("#fieldIsEL");
+  var $ELStatus_026 = $j("#fieldELStatus");
+  var $militaryStat_029 = $j("#fieldMilitaryStatus");
+  var $gradPlan_033 = $j("#fieldGradPlan");
+  var $coreCompletion_037 = $j("#fieldCoreCompletion");
+  var $504Plan_039 = $j("#field504Plan");
   
   switch( $enrollmentStatus_012.val() ) {
     case '01':
@@ -607,11 +492,11 @@ function decodeDemoVals() {
   }
   
   /* Decode ambiguous non-DOE values */
-  var $excludeState = $j( "form input#fieldExcludeState" );
-  var $includeSIMS = $j( "form input#fieldIncludeSIMS" );
-  var $includeSASID = $j( "form input#fieldIncludeSASID" );
-  var $entryGrade = $j( "form input#fieldEntryGrade" );
-  var $title1NCLB = $j( "form input#fieldNCLB" ); 
+  var $excludeState = $j("#fieldExcludeState");
+  var $includeSIMS = $j("#fieldIncludeSIMS");
+  var $includeSASID = $j("#fieldIncludeSASID");
+  var $entryGrade = $j("#fieldEntryGrade");
+  var $title1NCLB = $j("#fieldNCLB"); 
   
   switch( $excludeState.val() ) {
     case 'False':
@@ -672,8 +557,3 @@ function decodeDemoVals() {
       $entryGrade.addClass("noValue");
   }
 }
-/*
- NOTES:
-  + Every main section should have a Go to Top/Bottom
-	+ Name the Menu Item LPS Demographics
-*/

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -1,32 +1,37 @@
-function AddGDfields(){
+/*
+  -Insert custom fields & elements from hidden div into Demographics page
+*/
+function addLPSGDFields() {
   var $trHomePhone =  $j( "form input#fieldHomePhone" ).parent().parent();
   var $trRaceCode = $j( "form td:contains('MA Race Code')" ).parent();
   var $trGradYear = $j( "form input#fieldGradYear" ).parent().parent();
   var $trStuNum = $j( "form input#fieldStuNum" ).parent().parent();
   var $trMomHomePhone = $j( "form input#fieldMotherHomePhone" ).parent().parent();
-  /* Tables are built bottom-to-top */
-  /* Insert Custom 'Student' Fields */
+  
+    /*================NOTES:======================================================
+   -Tables are built bottom-to-top
+   -Sections of entirely custom fields are inserted after MA Race Code, just need
+      them in the table and don't think original placement matters. Race code 
+      defaults to bottom so this should avoid conflicts.
+   -Contacts Table is wrapped in a <div>, copied from Contacts page minus 
+      certain features.
+  ============================================================================*/
+  /* 'Student' Fields */
   $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_LPSEmail") );
   $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_PersonalEmail") );
   $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_Mobile") );
-  /*
-  NOTES:
-  -Tossing Sections of entirely custom fields in after MA Race Code, just need them in the table and don't think original placement matters too much
-    race code was originally at the bottom so this should avoid conflicts */
-  /* Insert Custom 'Contacts' Fields */
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_Parents_old") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_Guardians_old") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_EmergencyContacts") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_OtherContacts") );
   
-  /* Insert Custom 'Ethnicity/Race' Fields */
+  /* 'Contacts' Table */
+  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable div#demoContactsSection") );
+  
+  /* 'Ethnicity/Race' Fields */
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_Military") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_BirthCity") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSASID") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSIMS") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_ExcludeState") );  
   
-  /* Insert Custom 'Adminstrative' Fields */
+  /* 'Adminstrative' Fields */
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_504Plan") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_SPEDCode") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_FLEPDate") );
@@ -35,21 +40,17 @@ function AddGDfields(){
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_EntryGrade") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_EntryDate") );
   
-  /* Insert Custom 'Graduation' Fields */
+  /* 'Graduation' Fields */
   $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_CoreCompletion") );
   $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Plan") );
   $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Cohort") );
   $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Date") );
   
-  /* Insert Custom 'Legal' fields */
+  /* 'Legal' fields */
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trLegal_FullName") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trLegal_Gender") );
   
-  /* 
-    Insert Custom 'Other' Fields
-    NOTES: 
-      -Putting 'other-lps' items after 'other-builtIn' items 
-  */
+  /* 'Other' Fields */
   $j( "form input#fieldPrevStuId" ).parent().parent().after( $j("div#LPS-GDCustomhiddentable tr#trselectGradeLvl") );
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_TeamFlag") );
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_OriginCountry") );
@@ -63,24 +64,33 @@ function AddGDfields(){
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_FirstYearEL") );
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_NCLB") );
   
-  /* Insert Navigation Tabs */
-  var stu_header = $j("div#content-main p#student_detail_header"); /* seems like bad practice but should work for now */
-  var navTabs = $j("div#LPS-GDCustomhiddentable div#demo-navTabs");
-  stu_header.after(navTabs);
-  navTabs.append( $j("div#content-main form") );
+  /* Navigation Tabs */
+  var $stu_header = $j("div#content-main p#student_detail_header"); /* seems like bad practice but should work for now */
+  var $navTabs = $j("div#LPS-GDCustomhiddentable div#demo-navTabs");
+  $stu_header.after($navTabs);
+  $navTabs.append( $j("div#content-main form") );
+  
+  /* Navbar for "Show All" view */
+  var $navbar = $j("div#LPS-GDCustomhiddentable nav#demo-navbar");
+  $stu_header.after($navbar);
+  
+  /* Comment Box */
+  $j("form>div.box-round:first-child").after( $j("#demoComments") );
 
   $j( "div#LPS-GDCustomhiddentable" ).remove();
 }
-    
+ 
+/*
+  -Add LPS classes to PowerSchool default fields
+  -Wrap related fields into sections and rebuild table using sections
+  -Add sub-section headers
+*/
 function LPSGDRestyle() {
-
-  /*              
-    Student Information
+  /* Student Information
   -----------------Name--------------- */
-  $j( "form input#lastName" ).parent().parent().addClass( "row-student student-name" ); /*First = 003, Middle = 004, Last = 005*/
+  $j( "form input#lastName" ).parent().parent().addClass( "row-student student-name" ); /* DOE###: First = 003, Middle = 004, Last = 005*/
   /* ----------Home_Address----------- */
   $j( "form td:contains('Home Address')" ).not("td:contains('Mailing Address')").parent().addClass( "row-student student-address" );
-  //$j( "form td:contains('~[text:psx.html.admin_students.generaldemographics.home_address]')" ).not("td:contains('Mailing Address')").parent().addClass( "row-student student-address" );
   /*st, apt*/
   $j( "form input#pstreet" ).parent().parent().addClass( "row-student student-address" );
   $j( "form input#papt" ).parent().parent().addClass( "row-student student-address" );
@@ -109,14 +119,6 @@ function LPSGDRestyle() {
   
   /* Guardian/Contacts Information 
   -------------------------------- */
-  /*$( "input #" ).parent().parent().addClass( "row-contacts" )
-  /*
-    TODO: Fields Needed
-      -Contacts
-      -Emergency Contacts
-      -Original Guardian 1 (old)
-      -Original Guardian 2 (old)
-  */
   $j( "form td#father" ).parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
   $j( "form input#fieldFatherDayPhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
   $j( "form input#fieldFatherHomePhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
@@ -126,49 +128,22 @@ function LPSGDRestyle() {
   $j( "form input#fieldMotherHomePhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
   $j( "form input#fieldMotherEmployer" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
   
-  /*$j( "form tr#trContacts_Guardians_old" ).addClass( "row-contacts contacts-guardians" );
-  $j( "form tr#trContacts_EmergencyContacts" ).addClass( "row-contacts contacts-emergency" );
-  $j( "form tr#trContacts_OtherContacts" ).addClass( "row-contacts contacts-std" );*/
-  
   /* Ethnicity/Race/Other State Fields
-  -----------Ethnicity_&_Race---------DOE[008, 010, 029]
-    Notes:
-      -Two 'type = "hidden"' inputs above race selection box:
-        ids = "hiddenFieldSaveRace", "r_none_storage"
-      -Ethnicity & Race selections are nested in two <div> elements
-        .parent() x2
-  */
+  -----------Ethnicity_&_Race--------- */
   $j( "form td:contains('Federal Ethnicity and Race')" ).parent().addClass( "row-ethRace ethrace-select" );  /* Federal Ethnicity and Race */
   $j( "form td:contains('Massachusetts State Information')" ).parent().addClass( "row-ethRace ethrace-select" );  /* Massachusetts State Information */
   $j( "form input#radioFedEthYes" ).parent().parent().parent().parent().addClass( "row-ethRace ethrace-select" );  /* DOE010 (Hispanic/Latino) */
   $j( "form input#race_A" ).parent().parent().parent().parent().addClass( "row-ethRace ethrace-select" ); /* DOE010 (Race) */
-  $j( "form td:contains('MA Race Code')" ).parent().addClass( "row-ethRace ethrace-select" ); /* DOE010 Race code (could be autoCalculated from two fields above?)  */
-  /* -------Other_State_General------- */
-  $j( "form tr#trRace_ExcludeState" ).addClass( "row-ethRace ethrace-other" );
-  $j( "form tr#trRace_IncludeSIMS" ).addClass( "row-ethRace ethrace-other" );
-  $j( "form tr#trRace_IncludeSASID" ).addClass( "row-ethRace ethrace-other" );
-  $j( "form tr#trRace_BirthCity" ).addClass( "row-ethRace ethrace-other" );  /* DOE008 */
-  $j( "form tr#trRace_Military" ).addClass( "row-ethRace ethrace-other" );  /* DOE029 */
+  $j( "form td:contains('MA Race Code')" ).parent().addClass( "row-ethRace ethrace-select" ); /* DOE010 Race code */
   
-  /* LPS Office Information
-  --------General_Info----- */
-  $j( "form tr#trOffice_EntryDate" ).addClass( "row-office office-general" );
-  $j( "form tr#trOffice_EntryGrade" ).addClass( "row-office office-general" ); 
-  $j( "form tr#trOffice_SchoolCode" ).addClass( "row-office office-general" ); /* DOE015 */
-  /* -------EL_Info-------- */
-  $j( "form tr#trOffice_ELCode" ).addClass( "row-office office-el" ); /* DOE027 or 24? maybe 41? */
-  $j( "form tr#trOffice_FLEPDate" ).addClass( "row-office office-el" );
-  /* ------SPED_Info------- */
-  $j( "form tr#trOffice_SPEDCode" ).addClass( "row-office office-sped" ); /* DOE032, 34, 36, 38, or 40? */
-  $j( "form tr#trOffice_504Plan" ).addClass( "row-office office-sped" ); /* DOE039 */
-  
+  /* 
+    LPS Office Information
+      - Fields are initialized w/ proper classes 
+  */
+
   /* LPS Graduation
   --------Info----- */
   $j( "form input#fieldGradYear" ).parent().parent().addClass( "row-grad" );
-  $j( "form tr#trGrad_CoreCompletion" ).addClass( "row-grad" ); /* DOE037 */
-  $j( "form tr#trGrad_Plan" ).addClass( "row-grad" ); /* DOE033 */
-  $j( "form tr#trGrad_Cohort" ).addClass( "row-grad" );
-  $j( "form tr#trGrad_Date" ).addClass( "row-grad" );
   
   /* Legal Information
   ------Name/Gender------ */
@@ -209,11 +184,11 @@ function LPSGDRestyle() {
   $j("form div#EverythingElseSection").insertAfter( $j("form div#StudentSection") );
   /*
     NOTES:
-    -Adding a header with a fixed width so that other rows will fill in table space
+    -Adding a header with fixed width so other rows will fill in table space
     -Probably a lazy way format the page, should change later to be more dynamic
   */
   $j("form .row-everythingElse").children("td:nth-child(2)").attr("width", "75%");
-  $VarEverythingElse.first().before('<tr class="headerrow row-everythingElse"><td colspan="2" class="bold" width="1920px">Information</td></tr>')
+  $VarEverythingElse.first().before('<tr class="headerrow row-everythingElse"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
   
   /* Wrap Other Section */
   $j("form tr.row-other").wrapAll('<div id="OtherSection" class=""><div class="row"></div></div>');
@@ -249,29 +224,167 @@ function LPSGDRestyle() {
   $j("form tr.ethrace-other:first").before('<tr class="headerrow row-ethRace ethrace-other"><td colspan="2" class="bold" width="1920px">Other State General</td></tr>');
   
   /* Wrap Contacts Section */
+  $j("form div#demoContactsSection").wrapAll('<tr class="row-contacts contacts-table"><td colspan="2"></td></tr>');
   $j("form tr.row-contacts").wrapAll('<div id="ContactsSection" class=""><div class="row"></div></div>');
   $j("form div#ContactsSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("form tr.contacts-std:first").before( '<tr class="headerrow row-contacts contacts-std"> <td></td> <td class="bold">Contact 1</td> <td class="bold">Contact 2</td> </tr>');
-  $j("form tr.contacts-emergency:first").before('<tr class="headerrow row-contacts contacts-emergency"> <td></td> <td class="bold">E-Contact 1</td> <td class="bold">E-Contact 2</td> </tr>');
-  $j("form tr.contacts-guardians:first").before('<tr class="headerrow row-contacts contacts-guardians"> <td></td> <td class="bold">Guardian 1</td> <td class="bold">Guardian 2</td> </tr>');
   $j("form tr.contacts-parentsOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld"> <td colspan="2" class="bold" width="1920px">Parents - Old (will be phased out)</td> </tr>');
   $j("form tr.contacts-fatherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-fatherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Father - Old</td> </tr>');
   $j("form tr.contacts-motherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-motherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Mother - Old</td> </tr>');
+}
+
+/* Hides all sections except selected, essentially reverts to tabnav-form */
+function hideSections() {
+  $j(".collapseHeader").remove();
+  
+}
+
+/* Adds toggle-collapse headers to sections & activates navbar functions */
+function toggleShowAll() {
+  $j("form div#StudentSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Student Information</h2>').attr("style", "display: block !important");
+  $j("form div#EverythingElseSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Everything Else</h2>').attr("style", "display: block !important");
+  $j("form div#OtherSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Other</h2>').attr("style", "display: block !important");
+  $j("form div#LegalSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Legal Information</h2>').attr("style", "display: block !important");
+  $j("form div#GradSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Graduation Information</h2>').attr("style", "display: block !important");
+  $j("form div#OfficeSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Administrative Information</h2>').attr("style", "display: block !important");
+  $j("form div#EthRaceSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Ethnicity/Race Information</h2>').attr("style", "display: block !important");
+  $j("form div#ContactsSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Contacts</h2>').attr("style", "display: block !important");
+  
+  /* Navbar - Section Links */
+  $j(".sectLink").on('click', function(event) {
+    /* Check for hash(anchor link) value NOTE: this.hash returns part of URL beginning with '#' aka the id of the linked element */
+    if (this.hash !== "") {
+      event.preventDefault();
+      var sectionAnchor = this.hash;
+      
+      if ( $j(sectionAnchor).hasClass("hide") ) {
+        $j(sectionAnchor).prev().toggleClass("collapsed expanded");
+        $j(sectionAnchor).toggleClass("hide");
+      }
+      if ( $j(sectionAnchor).length < 1 ) {
+        alert("Error: Section " + sectionAnchor + " does not exist");
+        return false;
+      }
+      
+      /* Animate smooth scroll + add hash (#) to URL when done (default click behavior) */
+      $j('html, body').animate( { scrollTop: $j(sectionAnchor).offset().top },
+        800, function () { window.location.hash = sectionAnchor; }
+      );
+    }
+  });
+  /* Navbar - Expand All */
+  $j("#expandAll").on('click', function(event) {
+    event.preventDefault();
+    $j(".sectLink").each( function(index, elmnt) {
+      var $section = $j(elmnt.hash);
+      $section.removeClass("hide");
+      $section.prev().removeClass("collapsed").addClass("expanded");
+    });
+  });
+  /* Navbar - Collapse All */
+  $j("#collapseAll").on('click', function(event) {
+    event.preventDefault();
+    $j(".sectLink").each( function(index, elmnt) {
+      var $section = $j(elmnt.hash);
+      $section.addClass("hide");
+      $section.prev().removeClass("expanded").addClass("collapsed");
+    });
+  });
+  /* Navbar - Slide Down/Up */
+  window.onscroll = function() {
+    if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+      document.getElementById("demo-navbar").style.top = "0";
+    } else {
+      document.getElementById("demo-navbar").style.top = "-100px";
+    }
+  };
+  
+}
+
+/* 
+  -Run LPS customization functions
+  -Initialize event listeners
+  -Could be replaced by surrounding code in single block 
+*/
+$j(document).ready(function() {
+  /* Add LPS customizations to GD page then restyle page with the new elements */
+  addLPSGDFields();
+  LPSGDRestyle();
+  
+  /* Event Listeners */
+  var $showAllChkbx = $j("#demoShowAllCheckBox");
+  var $showAllTab = $j("#demoShowAllTab");
+  
+  /*
+    When checkbox is...
+     -Checked: Switch to "Show All" view
+     -Unchecked: Switch to tabbed view
+  */
+  $showAllChkbx.change(function() {
+    if ( $j( this ).checked ) {
+      toggleShowAll();
+    } else {
+      hideSections();
+    }
+  });
+  
+  $showAllTab.click(function (event) {
+    event.preventDefault();
+    $showAllChkbx.click();
+  });
+  
+  /*
+  Beginning of concept for other tabs to leave "Show All" view instead of acting like navbar
+    $j(".sectTab").not($showAllTab).click(function() {
+      if ( $showAllChkbx.checked ) {
+        $showAllChkbx.click();
+      }
+    });
+  */
   
   /* 
-  ---------Update Sections so they get 'ui-tabs' classes---------
+  ---------Update Sections so they get 'ui-tabs' classes-----------
   -Section <div>s don't receive PS 'ui-tabs' classes until clicked, 
-    so simulate a click on each tab when page loads then
-    click back to starting section (Students)
+    simulate a click on each tab when page loads then go back to
+    default tab ('Show All')
   */
-  $j(".sectLink").click();
-  $j(".sectLink[href='#StudentSection']").click();
+  $j("a.sectTab").click();
+  $j("a.sectTab[href='#demoShowAllTab']").click();
   
   /* Remove whitespace from field values, lets DOM know when they are empty for CSS */
   $j( "input" ).val(function( index, value ) { return value.trim(); });
   
-  /* Translate DOE Codes - 'fieldName_DOE###' */
+  /* Translate DOE Codes - 'fieldName_DOE###' (Moved to seperate function for readability) */
+  decodeDemoVals();
+  
+  /* Load page with all sections collapsed */
+  $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
+    hideCollapseClasses($j(this));
+    hideCollapseText($j(this));
+    hideCollapseTarget($j(this));
+  });
+  
+  /* Comment codes */
+  var InstValues= {};
+      InstValues[' ']='';
+      InstValues['REG']='Registration';
+      InstValues['COA']='Change of Address';
+      InstValues['PCU']='Program Code Updates';
+      InstValues['HOME']='Homeless';
+      InstValues['TF']='TransferFrom-Original';
+      InstValues['WD']='Withdrawal';
+      InstValues['GC']='Grade Change';
+      InstValues['RE']='Re-Engaged';
+      InstValues['Other']='Other';
+});
+
+
+
+/* 
+  ~ Moved down here because scrolling through it was annoying ~
+  -Decode DOE fields + fields w/ ambiguous values
+*/
+function decodeDemoVals() {
   var $enrollmentStatus_012 = $j("form input#fieldEnrollmentStatus");
   var $firstYearEL_021 = $j("form input#fieldFirstYearEL");
   var $immigrantStatus_022 = $j("form input#fieldImmigrantStatus");
@@ -503,7 +616,7 @@ function LPSGDRestyle() {
       break;
   }
   
-  /* Translate ambiguous non-DOE values */
+  /* Decode ambiguous non-DOE values */
   var $excludeState = $j( "form input#fieldExcludeState" );
   var $includeSIMS = $j( "form input#fieldIncludeSIMS" );
   var $includeSASID = $j( "form input#fieldIncludeSASID" );
@@ -568,18 +681,7 @@ function LPSGDRestyle() {
       $title1NCLB.val("No value found")
       $entryGrade.addClass("noValue");
   }
-  
-  /* Start page with all sections collapsed */
-  $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
-    hideCollapseClasses($j(this));
-    hideCollapseText($j(this));
-    hideCollapseTarget($j(this));
-  } );
-  
 }
-
-$j(document).ready(AddGDfields);
-$j(document).ready(LPSGDRestyle);
 
 /*
  NOTES:

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -9,26 +9,24 @@ function AddGDfields(){
   $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_LPSEmail") );
   $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_PersonalEmail") );
   $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_Mobile") );
-  
+  /*
+  NOTES:
+  -Tossing Sections of entirely custom fields in after MA Race Code, just need them in the table and don't think original placement matters too much
+    race code was originally at the bottom so this should avoid conflicts */
   /* Insert Custom 'Contacts' Fields */
-  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_Parents_old") );
-  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_Guardians_old") );
-  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_EmergencyContacts") );
-  $trMomHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_OtherContacts") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_Parents_old") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_Guardians_old") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_EmergencyContacts") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trContacts_OtherContacts") );
   
   /* Insert Custom 'Ethnicity/Race' Fields */
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_Military") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_BirthCity") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSASID") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSIMS") );
-  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_ExcludeState") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_ExcludeState") );  
   
-  /*
-    Insert Custom 'Adminstrative' Fields
-    NOTES:
-      -Tossing rows in after RaceCode, just need them in the table and don't think original placement matters too much 
-      -Date fields not showing up
-  */
+  /* Insert Custom 'Adminstrative' Fields */
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_504Plan") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_SPEDCode") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_FLEPDate") );
@@ -43,8 +41,9 @@ function AddGDfields(){
   $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Cohort") );
   $trGradYear.after( $j("div#LPS-GDCustomhiddentable tr#trGrad_Date") );
   
-  /* TODO:Insert Custom 'Legal' fields */
-  
+  /* Insert Custom 'Legal' fields */
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trLegal_FullName") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trLegal_Gender") );
   
   /* 
     Insert Custom 'Other' Fields
@@ -62,6 +61,7 @@ function AddGDfields(){
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_ELStatus") );
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_IsEL") );
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_FirstYearEL") );
+  $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_NCLB") );
   
   /* Nav anchors + Expand/Collapse all */
   var stu_header = $j("div#content-main p#student_detail_header");
@@ -105,9 +105,6 @@ function LPSGDRestyle() {
   $j( "form span#validateMailingAddress" ).parent().parent().addClass( "row-student student-mail" );
   /* -----------Phone/Email----------- */
   $j( "form input#fieldHomePhone" ).parent().parent().addClass( "row-student student-contactInfo" );
-  $j( "form tr#trStudent_Mobile" ).addClass( "row-student student-contactInfo" );
-  $j( "form tr#trStudent_PersonalEmail" ).addClass( "row-student student-contactInfo" );
-  $j( "form tr#trStudent_LPSEmail" ).addClass( "row-student student-contactInfo" );
   
   /* Guardian/Contacts Information 
   -------------------------------- */
@@ -118,13 +115,19 @@ function LPSGDRestyle() {
       -Emergency Contacts
       -Original Guardian 1 (old)
       -Original Guardian 2 (old)
-      -Original Demo Father (old)
-      -Original Demo Mother (old)
   */
-  $j( "form tr#trContacts_Parents_old" ).addClass( "row-contacts contacts-parents" );
-  $j( "form tr#trContacts_Guardians_old" ).addClass( "row-contacts contacts-guardians" );
+  $j( "form td#father" ).parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
+  $j( "form input#fieldFatherDayPhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
+  $j( "form input#fieldFatherHomePhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
+  $j( "form input#fieldFatherEmployer" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-fatherOld");
+  $j( "form td#mother" ).parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
+  $j( "form input#fieldMotherDayPhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
+  $j( "form input#fieldMotherHomePhone" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
+  $j( "form input#fieldMotherEmployer" ).parent().parent().addClass("row-contacts contacts-parentsOld contacts-motherOld");
+  
+  /*$j( "form tr#trContacts_Guardians_old" ).addClass( "row-contacts contacts-guardians" );
   $j( "form tr#trContacts_EmergencyContacts" ).addClass( "row-contacts contacts-emergency" );
-  $j( "form tr#trContacts_OtherContacts" ).addClass( "row-contacts contacts-std" );
+  $j( "form tr#trContacts_OtherContacts" ).addClass( "row-contacts contacts-std" );*/
   
   /* Ethnicity/Race/Other State Fields
   -----------Ethnicity_&_Race---------DOE[008, 010, 029]
@@ -160,7 +163,7 @@ function LPSGDRestyle() {
   
   /* LPS Graduation
   --------Info----- */
-  $j( "form input#Grad_Year" ).parent().parent().addClass( "row-grad" );
+  $j( "form input#fieldGradYear" ).parent().parent().addClass( "row-grad" );
   $j( "form tr#trGrad_CoreCompletion" ).addClass( "row-grad" ); /* DOE037 */
   $j( "form tr#trGrad_Plan" ).addClass( "row-grad" ); /* DOE033 */
   $j( "form tr#trGrad_Cohort" ).addClass( "row-grad" );
@@ -168,13 +171,9 @@ function LPSGDRestyle() {
   
   /* Legal Information
   ------Name/Gender------ */
-  /*legal name*/
-  $j("input#legalLastName").parent().parent().addClass( "row-legal" );
-  $j("input#legalFirstName").parent().parent().addClass( "row-legal" );
-  $j("input#legalMiddleName").parent().parent().addClass( "row-legal" );
-  $j("input#legalSuffixTextInput").parent().parent().addClass( "row-legal" );
-  /*legal gender*/
-  $j("select#legalGenderSelect").parent().parent().addClass( "row-legal" );  /* DOE009*/
+  /* LEGAL FIELDS USING BUILT-IN | Not working (fields are made after page is loaded?) */
+  $j("form input#legalLastName").parent().parent().addClass( "row-legal" );
+  $j("form select#legalGenderSelect").parent().parent().addClass( "row-legal" );  /* DOE009*/
   
   /* Other-Unused(Builtin)
   -----------Info--------- */
@@ -183,28 +182,9 @@ function LPSGDRestyle() {
   $j( "form input#fieldSSN" ).parent().parent().addClass( "row-other other-builtIn" );
   $j( "form input#fieldStuNum" ).parent().parent().addClass( "row-other other-builtIn" );  /* DOE001 */
   $j( "form input#fieldPrevStuId" ).parent().parent().addClass( "row-other other-builtIn" );
-  $j( "form tr#trOther_GradeLvl" ).addClass( "row-other other-builtIn" );  /* DOE016 */
+  $j( "form td:contains('Grade Level')" ).parent().addClass( "row-other other-builtIn" );  /* DOE016 */
   $j( "form input#fieldGuardianEmail" ).parent().parent().addClass( "row-other other-builtIn" );
   $j( "form select#primaryethnicity" ).parent().parent().addClass( "row-other other-builtIn" );
-  
-  /* Other-Unused(LPS)
-  ---------Info------- */
-  /* $j( "form tr#trselectNCLB" ).addClass( "row-other other-lps" ); */
-  $j( "form tr#trOther_FirstYearEL" ).addClass( "row-other other-lps" );  /* DOE021 */
-  $j( "form tr#trOther_IsEL" ).addClass( "row-other other-lps" );  /* DOE025 */
-  $j( "form tr#trOther_ELStatus" ).addClass( "row-other other-lps" );  /* DOE026 */
-  $j( "form tr#trOther_SASID" ).addClass( "row-other other-lps" );  /* DOE002 */
-  $j( "form tr#trOther_IsImmigrant" ).addClass( "row-other other-lps" );  /* DOE022 */
-  $j( "form tr#trOther_EnrollmentStatus" ).addClass( "row-other other-lps" );  /* DOE012 */
-  $j( "form tr#trOther_TransferFrom" ).addClass( "row-other other-lps" );  
-  $j( "form tr#trOther_BirthState" ).addClass( "row-other other-lps" );  
-  $j( "form tr#trOther_OriginCountry" ).addClass( "row-other other-lps" );  /* DOE023 */
-  $j( "form tr#trOther_TeamFlag" ).addClass( "row-other other-lps" );
-  
-  /*
-    TODO: Fields Needed
-      -NCLB/Title I School Choice (Row 1)
-  */
    
   /*============'EVERYTHING ELSE' Catcher============*/
   $VarEverythingElse = $j("form > div.box-round > table.linkDescList > tbody > tr");
@@ -241,6 +221,7 @@ function LPSGDRestyle() {
   $j("div#LegalSection").insertAfter( $j("form div#StudentSection") );
   $j("div#LegalSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Legal Information</h2>');
   /* Wrap Subsections */
+  $j("tr.row-legal:first").before('<tr class="headerrow row-legal"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
   
   /* Wrap Grad Section */
   $j("form tr.row-grad").wrapAll('<div id="GradSection" class=""><div class="row"></div></div>');
@@ -274,65 +255,25 @@ function LPSGDRestyle() {
   $j("form tr.contacts-std:first").before( '<tr class="headerrow row-contacts contacts-std"> <td></td> <td class="bold">Contact 1</td> <td class="bold">Contact 2</td> </tr>');
   $j("form tr.contacts-emergency:first").before('<tr class="headerrow row-contacts contacts-emergency"> <td></td> <td class="bold">E-Contact 1</td> <td class="bold">E-Contact 2</td> </tr>');
   $j("form tr.contacts-guardians:first").before('<tr class="headerrow row-contacts contacts-guardians"> <td></td> <td class="bold">Guardian 1</td> <td class="bold">Guardian 2</td> </tr>');
-  $j("form tr.contacts-parents:first").before('<tr class="headerrow row-contacts contacts-parents"> <td></td> <td class="bold">Father</td> <td class="bold">Mother</td> </tr>');
+  $j("form tr.contacts-parentsOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld"> <td colspan="2" class="bold" width="1920px">Parents - Old (will be phased out)</td> </tr>');
+  $j("form tr.contacts-fatherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-fatherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Father - Old</td> </tr>');
+  $j("form tr.contacts-motherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-motherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Mother - Old</td> </tr>');
   
-  /* Navbar - Section Links */
-  $j(".sectLink").on('click', function(event) {
-    /* Check for hash(anchor link) value NOTE: this.hash returns part of URL beginning with '#' aka the id of the linked element */
-    if (this.hash !== "") {
-      event.preventDefault();
-      var sectionAnchor = this.hash;
-      
-      if ( $j(sectionAnchor).hasClass("hide") ) {
-        $j(sectionAnchor).prev().toggleClass("collapsed expanded");
-        $j(sectionAnchor).toggleClass("hide");
-      }
-      if ( $j(sectionAnchor).length < 1 ) {
-        alert("Error: Section " + sectionAnchor + " does not exist");
-        return false;
-      }
-      
-      /* Animate smooth scroll + add hash (#) to URL when done (default click behavior) */
-      $j('html, body').animate( { scrollTop: $j(sectionAnchor).offset().top },
-        800, function () { window.location.hash = sectionAnchor; }
-      );
-    }
-  });
-  /* Navbar - Expand All */
-  $j("#expandAll").on('click', function(event) {
-    $j(".sectLink").each( function(index, elmnt) {
-      var $section = $j(elmnt.hash);
-      $section.removeClass("hide");
-      $section.prev().removeClass("collapsed").addClass("expanded");
-    });
-  });
-  /* Navbar - Collapse All */
-  $j("#collapseAll").on('click', function(event) {
-    $j(".sectLink").each( function(index, elmnt) {
-      var $section = $j(elmnt.hash);
-      $section.addClass("hide");
-      $section.prev().removeClass("expanded").addClass("collapsed");
-    });
-  });
-  /* Navbar - Slide Down/Up */
-  window.onscroll = function() {
-    if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-      document.getElementById("demo-navbar").style.top = "0";
-    } else {
-      document.getElementById("demo-navbar").style.top = "-100px";
-    }
-  };
+  /* Remove whitespace from field values, lets DOM know when they are empty for CSS */
+  $j( "input" ).val(function( index, value ) { return value.trim(); });
   
   /* Translate DOE Codes ('fieldName_DOE###') */
   var $enrollmentStatus_012 = $j("form input#fieldEnrollmentStatus");
   var $firstYearEL_021 = $j("form input#fieldFirstYearEL");
+  var $immigrantStatus_022 = $j("form input#fieldImmigrantStatus");
+  var $isEL_025 = $j("form input#fieldIsEL");
   var $ELStatus_026 = $j("form input#fieldELStatus");
   var $militaryStat_029 = $j("form input#fieldMilitaryStatus");
   var $gradPlan_033 = $j("form input#fieldGradPlan");
   var $coreCompletion_037 = $j("form input#fieldCoreCompletion");
   var $504Plan_039 = $j("form input#field504Plan");
   
-  switch($enrollmentStatus_012.val()) {
+  switch( $enrollmentStatus_012.val() ) {
     case '01':
       $enrollmentStatus_012.val("Enrolled");
       break;
@@ -398,9 +339,10 @@ function LPSGDRestyle() {
       break;
     default:
       $enrollmentStatus_012.val("No value found");
+      $enrollmentStatus_012.addClass("noValue");
       break;
   }  
-  switch($firstYearEL_021.val()) {
+  switch( $firstYearEL_021.val() ) {
     case '00':
       $firstYearEL_021.val("Does not apply");
       break;
@@ -412,9 +354,34 @@ function LPSGDRestyle() {
       break;
     default:
       $firstYearEL_021.val("No value found");
+      $firstYearEL_021.addClass("noValue");
       break;
   }
-  switch($ELStatus_026.val()) {
+  switch( $immigrantStatus_022.val() ) {
+    case '00':
+      $immigrantStatus_022.val("Student is not an immigrant student");
+      break;
+    case '01':
+      $immigrantStatus_022.val("Student is an immigrant student");
+      break;
+    default:
+      $immigrantStatus_022.val("No value found");
+      $immigrantStatus_022.addClass("noValue");
+      break;
+  }
+  switch( $isEL_025.val() ) {
+    case '00':
+      $isEL_025.val("Student is not an English Learner");
+      break;
+    case '01':
+      $isEL_025.val("Student is an English Learner");
+      break;
+    default:
+      $isEL_025.val("No value found");
+      $isEL_025.addClass("noValue");
+      break;
+  }
+  switch( $ELStatus_026.val() ) {
     case '00':
       $ELStatus_026.val("Not Enrolled in EL Program");
       break;
@@ -435,9 +402,10 @@ function LPSGDRestyle() {
       break;
     default:
       $ELStatus_026.val("No value found");
+      $ELStatus_026.addClass("noValue");
       break;
   }
-  switch($militaryStat_029.val()) {
+  switch( $militaryStat_029.val() ) {
     case '00':
       $militaryStat_029.val("Not a member of a military family");
       break;
@@ -452,9 +420,10 @@ function LPSGDRestyle() {
       break;
     default:
       $militaryStat_029.val("No value found");
+      $militaryStat_029.addClass("noValue");
       break;
   }
-  switch($gradPlan_033.val()) {
+  switch( $gradPlan_033.val() ) {
     case '01':
       $gradPlan_033.val("Four-Year Public College");
       break;
@@ -490,9 +459,10 @@ function LPSGDRestyle() {
       break;
     default:
       $gradPlan_033.val("No value found");
+      $gradPlan_033.addClass("noValue");
       break;
   }
-  switch($coreCompletion_037.val()) {
+  switch( $coreCompletion_037.val() ) {
     case '00':
       $coreCompletion_037.val("Student is not a graduate");
       break;
@@ -504,9 +474,10 @@ function LPSGDRestyle() {
       break;
     default:
       $coreCompletion_037.val("No value found");
+      $coreCompletion_037.addClass("noValue");
       break;
   }
-  switch($504Plan_039.val()) {
+  switch( $504Plan_039.val() ) {
     case '00':
       $504Plan_039.val("Has not been on a 504 plan at all this school year");
       break;
@@ -518,8 +489,98 @@ function LPSGDRestyle() {
       break;
     default:
       $504Plan_039.val("No value found");
+      $504Plan_039.addClass("noValue");
       break;
   }
+  
+  /* Translate ambiguous non-DOE values */
+  var $excludeState = $j( "form input#fieldExcludeState" );
+  var $includeSIMS = $j( "form input#fieldIncludeSIMS" );
+  var $includeSASID = $j( "form input#fieldIncludeSASID" );
+  
+  switch( $excludeState.val() ) {
+    case 'False':
+      $excludeState.val("No, do not exclude from state reporting");
+      break;
+    case 'True':
+      $excludeState.val("Yes, exclude from state reporting");
+      break;
+    default:
+      $excludeState.val("No value found");
+      $excludeState.addClass("noValue");
+      break;
+  }
+  switch( $includeSIMS.val() ) {
+    case '0':
+      $includeSIMS.val("No, do not include in SIMS report");
+      break;
+    case '1':
+      $includeSIMS.val("Yes, include in SIMS report");
+      break;
+    default:
+      $includeSIMS.val("No value found");
+      $includeSIMS.addClass("noValue");
+      break;
+  }
+  switch( $includeSASID.val() ) {
+    case '0':
+      $includeSASID.val("No, do not include in SASID report");
+      break;
+    case '1':
+      $includeSASID.val("Yes, include in SASID report");
+      break;
+    default:
+      $includeSASID.val("No value found");
+      $includeSASID.addClass("noValue");
+      break;
+  }
+  
+  /* Navbar - Section Links */
+  $j(".sectLink").on('click', function(event) {
+    /* Check for hash(anchor link) value NOTE: this.hash returns part of URL beginning with '#' aka the id of the linked element */
+    if (this.hash !== "") {
+      event.preventDefault();
+      var sectionAnchor = this.hash;
+      
+      if ( $j(sectionAnchor).hasClass("hide") ) {
+        $j(sectionAnchor).prev().toggleClass("collapsed expanded");
+        $j(sectionAnchor).toggleClass("hide");
+      }
+      if ( $j(sectionAnchor).length < 1 ) {
+        alert("Error: Section " + sectionAnchor + " does not exist");
+        return false;
+      }
+      
+      /* Animate smooth scroll + add hash (#) to URL when done (default click behavior) */
+      $j('html, body').animate( { scrollTop: $j(sectionAnchor).offset().top },
+        800, function () { window.location.hash = sectionAnchor; }
+      );
+    }
+  });
+  /* Navbar - Expand All */
+  $j("#expandAll").on('click', function(event) {
+    $j(".sectLink").each( function(index, elmnt) {
+      var $section = $j(elmnt.hash);
+      $section.removeClass("hide");
+      $section.prev().removeClass("collapsed").addClass("expanded");
+    });
+  });
+  /* Navbar - Collapse All */
+  $j("#collapseAll").on('click', function(event) {
+    $j(".sectLink").each( function(index, elmnt) {
+      var $section = $j(elmnt.hash);
+      $section.addClass("hide");
+      $section.prev().removeClass("expanded").addClass("collapsed");
+    });
+  });
+  /* Navbar - Slide Down/Up */
+  window.onscroll = function() {
+    if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+      document.getElementById("demo-navbar").style.top = "0";
+    } else {
+      document.getElementById("demo-navbar").style.top = "-100px";
+    }
+  };
   
   /* Start page with all sections collapsed */
   $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
@@ -527,7 +588,7 @@ function LPSGDRestyle() {
     hideCollapseText($j(this));
     hideCollapseTarget($j(this));
   } );
-
+  
 }
 
 $j(document).ready(AddGDfields);

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -3,11 +3,20 @@ function AddGDfields(){
   var $trRaceCode = $j( "td:contains('MA Race Code')" ).parent();
   var $trGradYear = $j( "input#fieldGradYear" ).parent().parent();
   var $trStuNum = $j( "input#fieldStuNum" ).parent().parent();
-  
+  var $trMomHomePhone = $j( "input#fieldMotherHomePhone" ).parent().parent();
+  /* Tables are built bottom-to-top */
+  /* Insert Custom 'Student' Fields */
   $trHomePhone.after( $j("tr#trfieldStudent_LPSemail") );
   $trHomePhone.after( $j("tr#trfieldStudent_Personalemail") );
   $trHomePhone.after( $j("tr#trfieldStudent_Mobile") );
   
+  /* Insert Custom 'Contacts' Fields */
+  $trMomHomePhone.after( $j("tr#trfieldParents_old") );
+  $trMomHomePhone.after( $j("tr#trfieldGuardians_old") );
+  $trMomHomePhone.after( $j("tr#trfieldEmergencyContacts") );
+  $trMomHomePhone.after( $j("tr#trfieldContacts") );
+  
+  /* Insert Custom 'Ethnicity/Race' Fields */
   $trRaceCode.after( $j("tr#trselectMilitary") );
   $trRaceCode.after( $j("tr#trfieldBirthCity") );
   $trRaceCode.after( $j("tr#trcheckboxIncludeSASID") );
@@ -15,6 +24,7 @@ function AddGDfields(){
   $trRaceCode.after( $j("tr#trcheckboxExcludeState") );
   
   /*
+    Insert Custom 'Adminstrative' Fields
     NOTES:
       -Tossing rows in after RaceCode, just need them in the table and don't think original placement matters too much 
       -Date fields not showing up
@@ -27,16 +37,21 @@ function AddGDfields(){
   $trRaceCode.after( $j("tr#trselectEntryGrade") );
   $trRaceCode.after( $j("tr#trfieldEntryDate") );
   
+  /* Insert Custom 'Graduation' Fields */
   $trGradYear.after( $j("tr#trselectGradCoreCompletion") );
   $trGradYear.after( $j("tr#trselectGradPlan") );
   $trGradYear.after( $j("tr#trfieldCohort") );
   $trGradYear.after( $j("tr#trfieldGradDate") );
   
-  /* TODO: Legal fields */
+  /* TODO:Insert Custom 'Legal' fields */
   
+  
+  /* 
+    Insert Custom 'Other' Fields
+    NOTES: 
+      -Putting 'other-lps' items after 'other-builtIn' items 
+  */
   $j( "input#fieldPrevStuId" ).parent().parent().after( $j("tr#trselectGradeLvl") );
-  
-  /* Putting other-lps items after other-builtIn items */
   $trStuNum.after( $j("tr#trselectTeamFlag") );
   $trStuNum.after( $j("tr#trselectOriginCountry") );
   $trStuNum.after( $j("tr#trselectBirthState") );
@@ -106,6 +121,10 @@ function LPSGDRestyle() {
       -Original Demo Father (old)
       -Original Demo Mother (old)
   */
+  $j( "tr#trfieldParents_old" ).addClass( "trsectionContacts contacts-parents" );
+  $j( "tr#trfieldGuardians_old" ).addClass( "trsectionContacts contacts-guardians" );
+  $j( "tr#trfieldEmergencyContacts" ).addClass( "trsectionContacts contacts-emergency" );
+  $j( "tr#trfieldContacts" ).addClass( "trsectionContacts contacts-std" );
   
   /* Ethnicity/Race/Other State Fields
   -----------Ethnicity_&_Race---------DOE[008, 010, 029]
@@ -196,24 +215,12 @@ function LPSGDRestyle() {
   $VarEverythingElse = ($VarEverythingElse).not("tr.trsectionOther");
   $VarEverythingElse.addClass( "trsectionEverythingElse" );
   
-  /* Wrap Student Section */
+  /* Wrap 'Student' Section */
   $j("tr.trsectionStudent").wrapAll('<div id="StudentSection" class=""><div class="row"></div></div>'); /* Starts at top */
   $j("div#StudentSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Student Information</h2>');
   /* Wrap Subsections */
   $j("tr.student-contactInfo:first").before('<tr class="headerrow trsectionStudent student-contactInfo"><td colspan="2" class="bold">Phone & Email</td></tr>');
   $j("tr.student-name:first").before('<tr class="headerrow trsectionStudent student-name"><td colspan="2" class="bold">Name</td></tr>');
-  
-  
-  /* Backup headers
-  $j("tr.student-name").wrapAll('<div id="student-name" class=""><div class="row"></div></div>');
-  $j("div#student-name").before('<h2 class="toggle expanded" title="Click here to expand or collapse" style="">Name</h2>');
-  $j("tr.student-address").wrapAll('<div id="student-address" class=""><div class="row"></div></div>');
-  $j("div#student-address").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Home Address</h2>');
-  $j("tr.student-mail").wrapAll('<div id="student-mail" class=""><div class="row"></div></div>');
-  $j("div#student-mail").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Mailing Address</h2>');
-  $j("tr.student-contactInfo").wrapAll('<div id="student-contactInfo" class=""><div class="row"></div></div>');
-  $j("div#student-contactInfo").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Phone & Email</h2>');
-  */
   /* 
     Home address row still shows up twice at bottom, don't know how they work.
       Possible Solution: Remove 'student-address' class from headerrows and select $j( "td.student-address:contains('Home Address')" )
@@ -225,28 +232,27 @@ function LPSGDRestyle() {
   $j("div#EverythingElseSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Everything Else</h2>');
   /* Wrap Subsections */
   
-  
-  /* Wrap Other Section */
+  /* Wrap 'Other' Section */
   $j("tr.trsectionOther").wrapAll('<div id="OtherSection" class=""><div class="row"></div></div>');
   $j("div#OtherSection").insertAfter( $j("div#StudentSection") );
   $j("div#OtherSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Other</h2>');
   /* Wrap Subsections */
   $j("tr.trsectionOther:first").before('<tr class="headerrow trsectionOther"><td colspan="2" class="bold">Information</td></tr>');
   
-  /* Wrap Legal Section */
+  /* Wrap 'Legal' Section */
   $j("tr.trsectionLegal").wrapAll('<div id="LegalSection" class=""><div class="row"></div></div>');
   $j("div#LegalSection").insertAfter( $j("div#StudentSection") );
   $j("div#LegalSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Legal Information</h2>');
   /* Wrap Subsections */
   
-  /* Wrap Grad Section */
+  /* Wrap 'Grad' Section */
   $j("tr.trsectionGrad").wrapAll('<div id="GradSection" class=""><div class="row"></div></div>');
   $j("div#GradSection").insertAfter( $j("div#StudentSection") );
   $j("div#GradSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Graduation Information</h2>');
   /* Wrap Subsections */
   $j("tr.trsectionGrad:first").before('<tr class="headerrow trsectionGrad"><td colspan="2" class="bold">Information</td></tr>');
   
-  /* Wrap Office Section*/
+  /* Wrap 'Office' Section*/
   $j("tr.trsectionOffice").wrapAll('<div id="OfficeSection" class=""><div class="row"></div></div>');
   $j("div#OfficeSection").insertAfter( $j("div#StudentSection") );
   $j("div#OfficeSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Administrative Information</h2>');
@@ -255,7 +261,7 @@ function LPSGDRestyle() {
   $j("tr.office-el:first").before('<tr class="headerrow trsectionOffice office-el"><td colspan="2" class="bold">EL Information</td></tr>');
   $j("tr.office-sped:first").before('<tr class="headerrow trsectionOffice office-sped"><td colspan="2" class="bold">SPED Information</td></tr>');
   
-  /* Wrap Race Section */
+  /* Wrap 'Race' Section */
   $j("tr.trsectionEthRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"></div></div>');
   $j("div#EthRaceSection").insertAfter( $j("div#StudentSection") );
   $j("div#EthRaceSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Ethnicity/Race Information</h2>');
@@ -263,11 +269,15 @@ function LPSGDRestyle() {
   $j("tr.ethrace-select:first").before('<tr class="headerrow trsectionEthRace ethrace-select"><td colspan="2" class="bold">Ethnicity & Race</td></tr>');
   $j("tr.ethrace-other:first").before('<tr class="headerrow trsectionEthRace ethrace-other"><td colspan="2" class="bold">Other State General</td></tr>');
   
-  /* Wrap Contacts Section */
+  /* Wrap 'Contacts' Section */
   $j("tr.trsectionContacts").wrapAll('<div id="ContactsSection" class=""><div class="row"></div></div>');
   $j("div#ContactsSection").insertAfter( $j("div#StudentSection") );
   $j("div#ContactsSection").before('<h2 class="toggle expanded" title="Click here to expand or collapse">Contacts</h2>');
   /* Wrap Subsections */
+  $j("tr.contacts-std:first").before( '<tr class="headerrow trsectionContacts contacts-std"> <td></td> <td class="bold">Contact 1</td> <td class="bold">Contact 2</td> </tr>');
+  $j("tr.contacts-emergency:first").before('<tr class="headerrow trsectionContacts contacts-emergency"> <td></td> <td class="bold">E-Contact 1</td> <td class="bold">E-Contact 2</td> </tr>');
+  $j("tr.contacts-guardians:first").before('<tr class="headerrow trsectionContacts contacts-guardians"> <td></td> <td class="bold">Guardian 1</td> <td class="bold">Guardian 2</td> </tr>');
+  $j("tr.contacts-parents:first").before('<tr class="headerrow trsectionContacts contacts-parents"> <td></td> <td class="bold">Father</td> <td class="bold">Mother</td> </tr>');
   
   /* Navbar - Section Links */
   $j(".sectLink").on('click', function(event) {
@@ -285,7 +295,7 @@ function LPSGDRestyle() {
         return false;
       }
       
-      /* Animate smooth scroll + add hash (#) to URL when done (default click behavior) */
+      /* Animate smooth scroll + add hash to URL when done (default click behavior) */
       $j('html, body').animate( { scrollTop: $j(sectionAnchor).offset().top },
         800, function () { window.location.hash = sectionAnchor; }
       );
@@ -322,19 +332,6 @@ function LPSGDRestyle() {
     hideCollapseText($j(this));
     hideCollapseTarget($j(this));
   } );
-  
-  
-  /* Not working like I want, not important enough to focus on rn
-  function stickScroll() {
-    var navbar = document.getElementById("demo-navbar");
-    if (window.pageYOffset >= navbar.offsetTop) {
-      $j(navbar).addClass("demo-sticky");
-    } else {
-      $j(navbar).removeClass("demo-sticky");
-    }
-  }
-  window.onscroll = function () { stickyScroll() }; 
-  */
 
 }
 

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -27,9 +27,14 @@ function addLPSGDFields() {
   /* 'Ethnicity/Race' Fields */
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_Military") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_BirthCity") );
+  $trRaceCode.after( $j("div#LPS-GDCustomhiddentable div#stateIncludeWrapper") );
+  var raceCodeViewBtn = '<td><button onclick="location.href=' + "'https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601'" + '" class="editButton" type="button">View</button></td>';
+  $trRaceCode.append( raceCodeViewBtn );
+  /*
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSASID") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSIMS") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_ExcludeState") );  
+  */
   
   /* 'Adminstrative' Fields */
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trOffice_504Plan") );
@@ -217,6 +222,7 @@ function LPSGDRestyle() {
   $j("form tr.office-sped:first").before('<tr class="headerrow row-office office-sped"><td colspan="2" class="bold" width="1920px">SPED Information</td></tr>');
   
   /* Wrap Race Section */
+  $j("form div#stateIncludeWrapper").wrapAll('<tr class="row-ethRace ethrace-other"><td colspan="2"></td></tr>');
   $j("form tr.row-ethRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"></div></div>');
   $j("form div#EthRaceSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -181,8 +181,8 @@ function LPSGDRestyle() {
   /* Wrap Student Section */
   $j("form tr.row-student").wrapAll('<div id="StudentSection" class=""><div class="row"></div></div>'); /* Starts at top */
   /* Wrap Subsections */
-  $j("form tr.student-contactInfo:first").before('<tr class="headerrow row-student student-contactInfo"><td colspan="2" class="bold" width="1920px">Phone & Email</td></tr>');
-  $j("form tr.student-name:first").before('<tr class="headerrow row-student student-name"><td colspan="2" class="bold" width="1920px">Name</td></tr>'); /* Currently using static px width, should adjust to be responsive */
+  $j("form tr.student-contactInfo:first").before('<tr class="headerrow row-student student-contactInfo"><td colspan="2" class="bold" width="100%">Phone & Email</td></tr>');
+  $j("form tr.student-name:first").before('<tr class="headerrow row-student student-name"><td colspan="2" class="bold" width="100%">Name</td></tr>'); /* Currently using static px width, should adjust to be responsive */
   
   /* Wrap 'Everything Else' (fields exist but don't have a section) */
   $VarEverythingElse.wrapAll('<div id="EverythingElseSection" class=""><div class="row"></div></div>'); /* Stack under Student Section */
@@ -193,48 +193,48 @@ function LPSGDRestyle() {
     -Probably a lazy way format the page, should change later to be more dynamic
   */
   $j("form .row-everythingElse").children("td:nth-child(2)").attr("width", "75%");
-  $VarEverythingElse.first().before('<tr class="headerrow row-everythingElse"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
+  $VarEverythingElse.first().before('<tr class="headerrow row-everythingElse"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Other Section */
   $j("form tr.row-other").wrapAll('<div id="OtherSection" class=""><div class="row"></div></div>');
   $j("form div#OtherSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("form tr.row-other:first").before('<tr class="headerrow row-other"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
+  $j("form tr.row-other:first").before('<tr class="headerrow row-other"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Legal Section */
   $j("form tr.row-legal").wrapAll('<div id="LegalSection" class=""><div class="row"></div></div>');
   $j("form div#LegalSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("form tr.row-legal:first").before('<tr class="headerrow row-legal"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
+  $j("form tr.row-legal:first").before('<tr class="headerrow row-legal"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Grad Section */
   $j("form tr.row-grad").wrapAll('<div id="GradSection" class=""><div class="row"></div></div>');
   $j("form div#GradSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("form tr.row-grad:first").before('<tr class="headerrow row-grad"><td colspan="2" class="bold" width="1920px">Information</td></tr>');
+  $j("form tr.row-grad:first").before('<tr class="headerrow row-grad"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Office Section*/
   $j("form tr.row-office").wrapAll('<div id="OfficeSection" class=""><div class="row"></div></div>');
   $j("form div#OfficeSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("form tr.office-general:first").before('<tr class="headerrow row-office office-general"><td colspan="2" class="bold" width="1920px">District Information</td></tr>');
-  $j("form tr.office-el:first").before('<tr class="headerrow row-office office-el"><td colspan="2" class="bold" width="1920px">EL Information</td></tr>');
-  $j("form tr.office-sped:first").before('<tr class="headerrow row-office office-sped"><td colspan="2" class="bold" width="1920px">SPED Information</td></tr>');
+  $j("form tr.office-general:first").before('<tr class="headerrow row-office office-general"><td colspan="2" class="bold" width="100%">District Information</td></tr>');
+  $j("form tr.office-el:first").before('<tr class="headerrow row-office office-el"><td colspan="2" class="bold" width="100%">EL Information</td></tr>');
+  $j("form tr.office-sped:first").before('<tr class="headerrow row-office office-sped"><td colspan="2" class="bold" width="100%">SPED Information</td></tr>');
   
   /* Wrap Race Section */
   $j("form div#stateIncludeWrapper").wrapAll('<tr class="row-ethRace ethrace-other"><td colspan="2"></td></tr>');
   $j("form tr.row-ethRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"></div></div>');
   $j("form div#EthRaceSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("form tr.ethrace-select:first").before('<tr class="headerrow row-ethRace ethrace-select"><td colspan="2" class="bold" width="1920px">Ethnicity & Race</td></tr>');
-  $j("form tr.ethrace-other:first").before('<tr class="headerrow row-ethRace ethrace-other"><td colspan="2" class="bold" width="1920px">Other State General</td></tr>');
+  $j("form tr.ethrace-select:first").before('<tr class="headerrow row-ethRace ethrace-select"><td colspan="2" class="bold" width="100%">Ethnicity & Race</td></tr>');
+  $j("form tr.ethrace-other:first").before('<tr class="headerrow row-ethRace ethrace-other"><td colspan="2" class="bold" width="100%">Other State General</td></tr>');
   
   /* Wrap Contacts Section */
   $j("form div#demoContactsSection").wrapAll('<tr class="row-contacts contacts-table"><td colspan="2"></td></tr>');
   $j("form tr.row-contacts").wrapAll('<div id="ContactsSection" class=""><div class="row"></div></div>');
   $j("form div#ContactsSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
-  $j("form tr.contacts-parentsOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld"> <td colspan="2" class="bold" width="1920px">Parents - Old (will be phased out)</td> </tr>');
+  $j("form tr.contacts-parentsOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld"> <td colspan="2" class="bold" width="100%">Parents - Old (will be phased out)</td> </tr>');
   $j("form tr.contacts-fatherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-fatherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Father - Old</td> </tr>');
   $j("form tr.contacts-motherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-motherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Mother - Old</td> </tr>');
 }
@@ -244,17 +244,18 @@ function hideSections() {
   $j(".collapseHeader").remove();
   
 }
-
+/* So this seems to create a copy of the whole page and place it below everything else for some reason, could be a result of bubbling on events? */
 /* Adds toggle-collapse headers to sections & activates navbar functions */
 function toggleShowAll() {
-  $j("form div#StudentSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Student Information</h2>').attr("style", "display: block !important");
-  $j("form div#EverythingElseSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Everything Else</h2>').attr("style", "display: block !important");
-  $j("form div#OtherSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Other</h2>').attr("style", "display: block !important");
-  $j("form div#LegalSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Legal Information</h2>').attr("style", "display: block !important");
-  $j("form div#GradSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Graduation Information</h2>').attr("style", "display: block !important");
-  $j("form div#OfficeSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Administrative Information</h2>').attr("style", "display: block !important");
-  $j("form div#EthRaceSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Ethnicity/Race Information</h2>').attr("style", "display: block !important");
-  $j("form div#ContactsSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Contacts</h2>').attr("style", "display: block !important");
+  $j("form div#StudentSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Student Information</h2>');
+  $j("form div#EverythingElseSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Everything Else</h2>');
+  $j("form div#OtherSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Other</h2>');
+  $j("form div#LegalSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Legal Information</h2>');
+  $j("form div#GradSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Graduation Information</h2>');
+  $j("form div#OfficeSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Administrative Information</h2>');
+  $j("form div#EthRaceSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Ethnicity/Race Information</h2>');
+  $j("form div#ContactsSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Contacts</h2>');
+  $j("form div").css("display", "block");
   
   /* Navbar - Section Links */
   $j(".sectLink").on('click', function(event) {
@@ -322,24 +323,6 @@ $j(document).ready(function() {
   var $showAllTab = $j("#demoShowAllTab");
   
   /*
-    When checkbox is...
-     -Checked: Switch to "Show All" view
-     -Unchecked: Switch to tabbed view
-  */
-  $showAllChkbx.change(function() {
-    if ( $j( this ).checked ) {
-      toggleShowAll();
-    } else {
-      hideSections();
-    }
-  });
-  
-  $showAllTab.click(function (event) {
-    event.preventDefault();
-    $showAllChkbx.click();
-  });
-  
-  /*
   Beginning of concept for other tabs to leave "Show All" view instead of acting like navbar
     $j(".sectTab").not($showAllTab).click(function() {
       if ( $showAllChkbx.checked ) {
@@ -368,6 +351,24 @@ $j(document).ready(function() {
     hideCollapseClasses($j(this));
     hideCollapseText($j(this));
     hideCollapseTarget($j(this));
+  });
+  
+  /*
+    When checkbox is...
+     -Checked: Switch to "Show All" view
+     -Unchecked: Switch to tabbed view
+  
+  $showAllChkbx.change(function() {
+    if ( $j( this ).checked ) {
+      toggleShowAll();
+    } else {
+      hideSections();
+    }
+  });
+  */
+  $showAllTab.click(function (event) {
+    event.preventDefault();
+    $showAllChkbx.click();
   });
   
   /* Comment codes */

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -7,7 +7,10 @@ function addLPSGDFields() {
   var $trGradYear = $j( "form input#fieldGradYear" ).parent().parent();
   var $trStuNum = $j( "form input#fieldStuNum" ).parent().parent();
   var $trMomHomePhone = $j( "form input#fieldMotherHomePhone" ).parent().parent();
-  
+  var raceCodeViewBtn = '<td><button onclick="location.href=' 
+    + "'https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601'" 
+    + '" class="editButton" type="button">View</button></td>';
+
     /*================NOTES:======================================================
    -Tables are built bottom-to-top
    -Sections of entirely custom fields are inserted after MA Race Code, just need
@@ -22,13 +25,12 @@ function addLPSGDFields() {
   $trHomePhone.after( $j("div#LPS-GDCustomhiddentable tr#trStudent_Mobile") );
   
   /* 'Contacts' Table */
-  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable div#demoContactsSection") );
+  $trHomePhone.after( $j("div#LPS-GDCustomhiddentable div#demoContactsTable") );
   
   /* 'Ethnicity/Race' Fields */
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_Military") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_BirthCity") );
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable div#stateIncludeWrapper") );
-  var raceCodeViewBtn = '<td><button onclick="location.href=' + "'https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601'" + '" class="editButton" type="button">View</button></td>';
   $trRaceCode.append( raceCodeViewBtn );
   /*
   $trRaceCode.after( $j("div#LPS-GDCustomhiddentable tr#trRace_IncludeSASID") );
@@ -70,21 +72,24 @@ function addLPSGDFields() {
   $trStuNum.after( $j("div#LPS-GDCustomhiddentable tr#trOther_NCLB") );
   
   /* Navigation Tabs */
-  var $stu_header = $j("div#content-main p#student_detail_header"); /* seems like bad practice but should work for now */
-  var $navTabs = $j("div#LPS-GDCustomhiddentable div#demo-navTabs");
-  $stu_header.after($navTabs);
-  $navTabs.append( $j("div#content-main form") );
+  var $navTabs = $j("div#LPS-GDCustomhiddentable div#demoNavTabs");
+  $j("div#content-main form").before($navTabs).appendTo($navTabs);
   
-  /* Navbar for "Show All" view */
-  var $navbar = $j("div#LPS-GDCustomhiddentable nav#demo-navbar");
-  $stu_header.after($navbar);
+  /* Navbar for collapsed view */
+  var $navBar = $j("div#LPS-GDCustomhiddentable nav#demoNavBar");
+  $navTabs.before($navBar);
+  $navTabs.before( $j("div#LPS-GDCustomhiddentable div#navToggleBox") );
+  
+  /* Style Options Section */
+  var $styleOptions = $j("div#LPS-GDCustomhiddentable div#demoStyleOptions");
+  $navTabs.before($styleOptions);
   
   /* Comment Box */
   $j("form>div.box-round:first-child").after( $j("#demoComments") );
 
   $j( "div#LPS-GDCustomhiddentable" ).remove();
 }
- 
+
 /*
   -Add LPS classes to PowerSchool default fields
   -Wrap related fields into sections and rebuild table using sections
@@ -230,23 +235,54 @@ function LPSGDRestyle() {
   $j("form tr.ethrace-other:first").before('<tr class="headerrow row-ethRace ethrace-other"><td colspan="2" class="bold" width="100%">Other State General</td></tr>');
   
   /* Wrap Contacts Section */
-  $j("form div#demoContactsSection").wrapAll('<tr class="row-contacts contacts-table"><td colspan="2"></td></tr>');
+  $j("form div#demoContactsTable").wrapAll('<tr class="row-contacts contacts-table"><td colspan="2"></td></tr>');
   $j("form tr.row-contacts").wrapAll('<div id="ContactsSection" class=""><div class="row"></div></div>');
   $j("form div#ContactsSection").insertAfter( $j("form div#StudentSection") );
   /* Wrap Subsections */
   $j("form tr.contacts-parentsOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld"> <td colspan="2" class="bold" width="100%">Parents - Old (will be phased out)</td> </tr>');
   $j("form tr.contacts-fatherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-fatherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Father - Old</td> </tr>');
   $j("form tr.contacts-motherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-motherOld"> <td colspan="2" class="bold" style="background-color:#7ba4b7">Mother - Old</td> </tr>');
+  
+  /* Insert showAll Section (Empty, used for anchor) ~Might just link to StudentSection instead~ */
+  //$j('<div id="ShowAll"></div>').insertBefore( $j("form div#StudentSection") );
 }
 
-/* Hides all sections except selected, essentially reverts to tabnav-form */
-function hideSections() {
-  $j(".collapseHeader").remove();
-  
+/* 
+  Hide all sections except selected, reverts to tabnav form
+    - Arg(s)  : Any valid JQuery selector
+        Default = "div#StudentSection"
+    - Returns : NULL
+*/
+function toggleDisplayNav() {
+  /* JQuery's .css("top", "--px") wouldn't work and this did so I'm using this */
+  var navBar = document.getElementById("demoNavBar"); 
+  var navToggle = document.getElementById("navToggleBox");
+  if(navBar.style.top === "-100px") {
+    navBar.style.top = "0px";
+    navToggle.style.transition = "top 0.2s ease 0.1s";
+    navToggle.style.top = "50px";
+    $j("a#toggleNavBar").text("\uD83E\uDC45"); // Up Arrow
+  } else {
+    navBar.style.top= "-100px";
+    navToggle.style.transition = "top 0.15s ease 0s";
+    navToggle.style.top = "0px";
+    $j("a#toggleNavBar").text("\uD83E\uDC47"); // Down Arrow
+  }
 }
+
+function hideCollapsed() {
+  $j(".collapseHeader").remove();
+  $j("#demoNavBar").css("top", "-100px"); // If Im going this way I can probably just dynamically add/remove it instead.
+  $j("div#navToggleBox").css( {"transition":"top 0.3s ease 0s","top":"-50px"} );
+  $j("#demoNavBar").off();
+  $j("#toggleNavBar").off();
+  $j('form div[id$="Section"]').removeClass("hide").css("display", "none");
+  $j("div#demoNavTabs > ul").prop("hidden", false);
+}
+
 /* So this seems to create a copy of the whole page and place it below everything else for some reason, could be a result of bubbling on events? */
 /* Adds toggle-collapse headers to sections & activates navbar functions */
-function toggleShowAll() {
+function showCollapsed() {
   $j("form div#StudentSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Student Information</h2>');
   $j("form div#EverythingElseSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Everything Else</h2>');
   $j("form div#OtherSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Other</h2>');
@@ -256,26 +292,35 @@ function toggleShowAll() {
   $j("form div#EthRaceSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Ethnicity/Race Information</h2>');
   $j("form div#ContactsSection").before('<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">Contacts</h2>');
   $j("form div").css("display", "block");
-  
-  /* Navbar - Section Links */
+  $j("div#demoNavTabs > ul").prop("hidden", true);
+  toggleDisplayNav();  
+   
+  /* Load page with all sections collapsed */
+  $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
+    hideCollapseClasses($j(this));
+    hideCollapseText($j(this));
+    hideCollapseTarget($j(this));
+  });
+
+  /* Add Navbar Event Listeners */
   $j(".sectLink").on('click', function(event) {
     /* Check for hash(anchor link) value NOTE: this.hash returns part of URL beginning with '#' aka the id of the linked element */
     if (this.hash !== "") {
       event.preventDefault();
-      var sectionAnchor = this.hash;
+      var $sectionAnchor = $j(this.hash);
       
-      if ( $j(sectionAnchor).hasClass("hide") ) {
-        $j(sectionAnchor).prev().toggleClass("collapsed expanded");
-        $j(sectionAnchor).toggleClass("hide");
+      if ( $sectionAnchor.hasClass("hide") ) {
+        $sectionAnchor.prev().toggleClass("collapsed expanded");
+        $sectionAnchor.toggleClass("hide");
       }
-      if ( $j(sectionAnchor).length < 1 ) {
-        alert("Error: Section " + sectionAnchor + " does not exist");
+      if ( $sectionAnchor.length < 1 ) {
+        alert("Error: Section " + this.hash + " does not exist");
         return false;
       }
       
       /* Animate smooth scroll + add hash (#) to URL when done (default click behavior) */
-      $j('html, body').animate( { scrollTop: $j(sectionAnchor).offset().top },
-        800, function () { window.location.hash = sectionAnchor; }
+      $j('html, body').animate( { scrollTop: $sectionAnchor.offset().top },
+        600, function () { window.location.hash = $sectionAnchor.attr('id'); }
       );
     }
   });
@@ -297,80 +342,75 @@ function toggleShowAll() {
       $section.prev().removeClass("expanded").addClass("collapsed");
     });
   });
-  /* Navbar - Slide Down/Up */
-  window.onscroll = function() {
+  /* Toggle NavBar On/Off */
+  $j("#toggleNavBar").on('click', function(event) {
+    event.preventDefault();
+    toggleDisplayNav();
+  });
+  
+  /* Navbar - Slide Down/Up - DEPRECATED: Navbar visibility now tied to "Show All"
+  window.onscroll = function navScroll() {
     if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-      document.getElementById("demo-navbar").style.top = "0";
+      $j("nav#demoNavBar").css("top", "0");
     } else {
-      document.getElementById("demo-navbar").style.top = "-100px";
+      $j("nav#demoNavBar").css("top", "-100px");
     }
   };
-  
+  */
 }
 
 /* 
   -Run LPS customization functions
   -Initialize event listeners
-  -Could be replaced by surrounding code in single block 
+  -Could be replaced by surrounding code in single block
 */
 $j(document).ready(function() {
   /* Add LPS customizations to GD page then restyle page with the new elements */
   addLPSGDFields();
   LPSGDRestyle();
   
-  /* Event Listeners */
-  var $showAllChkbx = $j("#demoShowAllCheckBox");
-  var $showAllTab = $j("#demoShowAllTab");
+  /* ----------------Event Listeners---------------- */
+  var $viewSelect = $j("select#demoViewStyles");
+  var curSection = location.hash.replace("#/","#"); // Cut out '/' because it causes issues
   
-  /*
-  Beginning of concept for other tabs to leave "Show All" view instead of acting like navbar
-    $j(".sectTab").not($showAllTab).click(function() {
-      if ( $showAllChkbx.checked ) {
-        $showAllChkbx.click();
-      }
-    });
-  */
+  /* View Style Selection */
+  $viewSelect.on("change", function(event) {
+    switch( $viewSelect.val() ) {
+      case 'Tab':
+        hideCollapsed();
+        if( /#.*Section/.test(location.href) ) {
+          $j('div#demoNavTabs a[href="'+ curSection +'"]').click();
+        } else {
+          $j('div#demoNavTabs a[href="#StudentSection"]').click();
+        }
+        break;
+      case 'Collapse':
+        showCollapsed();
+        break;
+      default:
+        hideCollapsed();
+        break;
+    }
+  });
   
   /* 
   ---------Update Sections so they get 'ui-tabs' classes-----------
   -Section <div>s don't receive PS 'ui-tabs' classes until clicked, 
     simulate a click on each tab when page loads then go back to
-    default tab ('Show All')
+    default tab ('#StudentSection')
   */
   $j("a.sectTab").click();
-  $j("a.sectTab[href='#demoShowAllTab']").click();
+  $j('a.sectTab[href="#StudentSection"]').click();
+  
+  /* Start in Collapsed View */
+  showCollapsed();
   
   /* Remove whitespace from field values, lets DOM know when they are empty for CSS */
   $j( "input" ).val(function( index, value ) { return value.trim(); });
   
   /* Translate DOE Codes - 'fieldName_DOE###' (Moved to seperate function for readability) */
   decodeDemoVals();
-  
-  /* Load page with all sections collapsed */
-  $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
-    hideCollapseClasses($j(this));
-    hideCollapseText($j(this));
-    hideCollapseTarget($j(this));
-  });
-  
-  /*
-    When checkbox is...
-     -Checked: Switch to "Show All" view
-     -Unchecked: Switch to tabbed view
-  
-  $showAllChkbx.change(function() {
-    if ( $j( this ).checked ) {
-      toggleShowAll();
-    } else {
-      hideSections();
-    }
-  });
-  */
-  $showAllTab.click(function (event) {
-    event.preventDefault();
-    $showAllChkbx.click();
-  });
-  
+
   /* Comment codes */
   var InstValues= {};
       InstValues[' ']='';
@@ -689,7 +729,6 @@ function decodeDemoVals() {
       $entryGrade.addClass("noValue");
   }
 }
-
 /*
  NOTES:
   + Every main section should have a Go to Top/Bottom

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -1,73 +1,8 @@
+<!DOCTYPE html>
 <!-- use jQuery to replace text -->
 <script src="/admin/javascript/LPSGDC.js"></script>
 <style type="text/css">
-/* Adjust navbar for screensize */
-  @media screen and (max-width: 1200px) {
-    #demo-navbar a {
-      font-size: 13px;
-      padding: 10px;
-    }
-  }
-  @media screen and (max-width: 840px) {
-    #demo-navbar a {
-      font-size: 10px;
-      padding: 7px;
-    }
-  }
-  /* 650px is when PS stops scaling the page  */
-  @media screen and (max-width: 650px) {
-    #demo-navbar a {
-      line-height: 1.5em;
-      font-size: 7px;
-      padding: 3px;
-    }
-  }
-  /* Maybe should change this to move links to a drop-down? */
-  @media screen and (max-width: 460px) {
-    #demo-navbar a {
-      font-size: 5px;
-      line-height: 1.5em;
-      padding: 2px;
-    }
-  }
-  
-  /* Slide-down navigation bar for section anchors */
-  #demo-navbar {
-    overflow: hidden;
-    background-color: #333;
-    position: fixed;
-    top: -100px;
-    width: 100%;
-    transition: top 0.3s;
-    z-index: 1;
-  }
-  #demo-navbar a {
-    float: left;
-    display: block;
-    color: #f2f2f2;
-    text-align: center;
-    padding: 15px;
-    text-decoration: none;
-    font-size: 17px;
-  }
-  #demo-navbar a:hover {
-    background-color: #ddd;
-    color: black;
-  }
-  #demo-navbar a.active {
-    background-color: #04AA6D;
-    color: white;
-  }
-
-  input:read-only {
-    border-style: inset;
-    border-width: 2px;
-    border-color: rgb(118,118,118) rgb(133,133,133) rgb(133,133,133) rgb(118,118,118);
-    padding: 3px;
-    background-color: rgb(255,255,255);
-    /*background-color: rgb(217,217,217);*/ /* highlight custom fields grey !!FOR BUG-FINDING/FIXING ONLY!! */
-  }
-  /* highlight fields: incomplete = red, completed = green !!FOR BUG-FINDING/FIXING ONLY!! */
+/* highlight fields: incomplete = red, completed = green !!FOR BUG-FINDING/FIXING ONLY!! */
   /*
   input:invalid {
     background-color: rgb(230, 179, 179);
@@ -82,17 +17,113 @@
     background-color: rgb(230, 179, 179);
   }
   */
-  input:only-child {
-    width: 99%;
+/* Adjust navbar for screensize */
+  @media screen and (max-width: 1200px) {
+    #demoNavBar a {
+      font-size: 13px;
+      padding: 10px;
+    }
+  }
+  @media screen and (max-width: 840px) {
+    #demoNavBar a {
+      font-size: 10px;
+      padding: 7px;
+    }
+  }
+  /* 650px is when PS stops scaling the page  */
+  @media screen and (max-width: 650px) {
+    #demoNavBar a {
+      line-height: 1.5em;
+      font-size: 7px;
+      padding: 3px;
+    }
+  }
+  /* Maybe should change this to move links to a drop-down? */
+  @media screen and (max-width: 460px) {
+    #demoNavBar a {
+      font-size: 5px;
+      line-height: 1.5em;
+      padding: 2px;
+    }
   }
   
-  .editButton {
-    float: right;
+/* Slide-down navigation bar for section anchors */
+  #demoNavBar {
+    position: fixed;
+    top: -100px;
+    width: 100%;
+    transition: top 0.3s;
+    overflow: hidden;
+    background-color: #333;
+    z-index: 1;
+  }
+  #demoNavBar a {
+    float: left;
+    display: block;
+    color: #f2f2f2;
+    text-align: center;
+    padding: 15px;
+    text-decoration: none;
+    font-size: 17px;
+  }
+  #demoNavBar a:hover {
+    background-color: #ddd;
+    color: black;
+  }
+  #demoNavBar a.active {
+    background-color: #04AA6D;
+    color: white;
+  }
+
+  #navToggleBox {
+    position: fixed;
+    top: -50px;
+    right: 50%;
+    width: 5%;
+    transition: top 0.2s ease 0.1;
+    overflow: hidden;
+    background-color: #333;
+    z-index: 1;
+  }
+  #navToggleBox a {
+    float: left;
+    display: block;
+    color: #f2f2f2;
+    text-align: center;
+    padding: 10px;
+    text-decoration: none;
+    font-size: 17px;
+  }
+  #navToggleBox a:hover {
+    background-color: #ddd;
+    color: black;
+  }
+  #navToggleBox a.active {
+    background-color: #04AA6D;
+    color: white;
+  }
+  #navToggleBox button {
+    float: left;
+    padding: 0px;
+    margin: 0px 0px 5px 12.5px;
+    line-height: 0.8em;
   }
   
-  #editStateIncludeBtn {
-    margin-top: 0px;
+/* Make read-only inputs look normal */
+  input:read-only {
+    border-style: inset;
+    border-width: 2px;
+    border-color: rgb(118,118,118) rgb(133,133,133) rgb(133,133,133) rgb(118,118,118);
+    padding: 3px;
+    background-color: rgb(255,255,255);
+    /*background-color: rgb(217,217,217); /* highlight custom fields grey !!FOR BUG-FINDING/FIXING ONLY!! */
   }
+  
+  input:only-child { width: 99%; }
+  
+  .editButton { float: right; }
+  
+  #editStateIncludeBtn { margin-top: 0px; }
   
   #stateIncludeBox {
     margin-left: 0px;
@@ -100,12 +131,8 @@
     margin-bottom: 0px;
   }
   
-  #demoContactsSection {
-    border-style: none;
-  }
-  #studentContactsTable {
-    width: calc(100% - 20px);
-  }
+  #demoContactsTable { border-style: none; }
+  #studentContactsTable { width: calc(100% - 20px); }
 </style>
 <!--
   NOTES:
@@ -118,7 +145,7 @@
   - Im going to want to change the edit links to not specificially link to frn=001113601
  -->
 <div id="LPS-GDCustomhiddentable" style="display: none;">
-  <nav id="demo-navbar">
+  <nav id="demoNavBar">
     <a href="#StudentSection" class="sectLink">Student</a>
     <a href="#ContactsSection" class="sectLink">Contacts</a>
     <a href="#EthRaceSection" class="sectLink">Ethnicity & Race</a>
@@ -127,18 +154,21 @@
     <a href="#LegalSection" class="sectLink">Legal</a>
     <a href="#OtherSection" class="sectLink">Other</a>
     <a href="#EverythingElseSection" class="sectLink">Everything Else</a>
-    <a href="#" id="expandAll">Expand All</a>
-    <a href="#" id="collapseAll">Collapse All</a>
+    <a href="javascript:void(0);" id="expandAll">Expand All</a>
+    <a href="javascript:void(0);" id="collapseAll">Collapse All</a>
   </nav>
-  <div class="tabs" id="demo-navTabs">
+  <div id="navToggleBox">
+    <button type="button" width="50%"><a href="javascript:void(0);" id="toggleNavBar">&#x1f845;</a></button>
+  </div>
+  <div id="demoStyleOptions">
+    <label for="demoViewStyles" id="viewLabel" style="margin-left: 2em">View Style: </label>
+    <select id="demoViewStyles">
+      <option value="Collapse" selected>Collapsed (default)</option>
+      <option value="Tab">Tabs</option>
+    </select>
+  </div>
+  <div class="tabs" id="demoNavTabs">
     <ul>
-      <!-- "Show All" option -->
-      <li> <!-- This is very broken oh lordy -->
-        <a href="#showAll" id="demoShowAllTab" class="sectTab">
-          <input type="checkbox" id="demoShowAllCheckBox" name="demoShowAllCheckBox" value="1" checked>
-          <label>Show All (Broken)</label>
-        </a>
-      </li>
       <li><a href="#StudentSection" class="sectTab">Student</a></li>
       <li><a href="#ContactsSection" class="sectTab">Contacts</a></li>
       <li><a href="#EthRaceSection" class="sectTab">Ethnicity & Race</a></li>
@@ -176,7 +206,6 @@
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/emailconfig.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
-      
       <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Needs to be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)" class="psTextWidget" readonly /></td>
@@ -316,34 +345,34 @@
     </tbody>
   </table>
 
-<!-- Grouping these 3 fields in a box-round to communicate that the "Edit" button functions the same for each -->
-<div id="stateIncludeWrapper" class="row-ethRace ethrace-other">
-  <div class="button-row" style="margin:0px;padding-bottom:0px;">
-    <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/stateMA.html?frn=~(frn)'" id="editStateIncludeBtn" type="button">Edit</button>
+  <!-- Grouping these 3 fields in a box-round to communicate that the "Edit" button functions the same for each -->
+  <div id="stateIncludeWrapper" class="row-ethRace ethrace-other">
+    <div class="button-row" style="margin:0px;padding-bottom:0px;">
+      <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/stateMA.html?frn=~(frn)'" id="editStateIncludeBtn" type="button">Edit</button>
+    </div>
+    <div class="box-round" id="stateIncludeBox">
+      <table class="linkDescList" style="margin-top:0px;width:100%;">
+        <colgroup>
+          <col style="width: auto">
+          <col style="width: 100%">
+        </colgroup>
+        <tbody width="100%">
+          <tr id="trRace_ExcludeState" class="">
+            <td class="bold">Exclude from State Reporting? &tilde;</td>
+            <td><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" class="psTextWidget" readonly /></td>
+          </tr> <!-- All "include/exclude" fields are in the same place so only need one edit button link -->
+          <tr id="trRace_IncludeSIMS" class="">
+            <td class="bold">Include in SIMS Report? &tilde;</td>
+            <td><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)" class="psTextWidget" readonly /></td>
+          </tr>
+          <tr id="trRace_IncludeSASID" class="">
+            <td class="bold">Include in SASID Report? &tilde;</td>
+            <td><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)" class="psTextWidget" readonly /></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
-  <div class="box-round" id="stateIncludeBox">
-    <table class="linkDescList" style="margin-top:0px;width:100%;">
-      <colgroup>
-        <col style="width: auto">
-        <col style="width: 100%">
-      </colgroup>
-      <tbody width="100%">
-        <tr id="trRace_ExcludeState" class="">
-          <td class="bold">Exclude from State Reporting? &tilde;</td>
-          <td><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" class="psTextWidget" readonly /></td>
-        </tr> <!-- All "include/exclude" fields are in the same place so only need one edit button link -->
-        <tr id="trRace_IncludeSIMS" class="">
-          <td class="bold">Include in SIMS Report? &tilde;</td>
-          <td><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)" class="psTextWidget" readonly /></td>
-        </tr>
-        <tr id="trRace_IncludeSASID" class="">
-          <td class="bold">Include in SASID Report? &tilde;</td>
-          <td><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)" class="psTextWidget" readonly /></td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
       
   <!--
     Copying Contacts page source and displaying it in Demographics 'Contacts' section.
@@ -354,7 +383,7 @@
   <!-- Start of Content & Bounding box <div controller = "studentPageContactsController"> : *Required* - used by Angular -->
   <div class="box-round" data-ng-controller="studentPageContactsController"
        data-require-path="components/contacts/index,components/widgets/dirtyInputHelper/index"
-       data-module-name="contactsModule" data-ng-cloak id="demoContactsSection">
+       data-module-name="contactsModule" data-ng-cloak id="demoContactsTable">
     <!-- Start of <div controller = "contactStudentController"> : Context container for Contacts table -->
     <div data-ng-controller="contactStudentController">
       <div class="button-row">

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -78,7 +78,7 @@
     <!--  Custom Fields: 'Student Info' -->
       <tr id="trStudent_Mobile" class="row-student student-contactInfo">
         <td class="bold">Student Mobile &tilde;</td><!-- where is this info stored? -->
-        <td width="75%"><input type="tel" id="fieldStudentMobile" placeholder="123-456-7890" readonly /></td>
+        <td width="75%"><input type="tel" id="fieldStudentMobile" value="" placeholder="123-456-7890" readonly /></td>
       </tr>
       <tr id="trStudent_PersonalEmail" class="row-student student-contactInfo">
         <td class="bold">Student Personal Email &tilde;</td>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -1,139 +1,7 @@
 <!DOCTYPE html>
 <!-- use jQuery to replace text -->
 <script src="/admin/javascript/LPSGDC.js"></script>
-<style type="text/css">
-/* highlight fields: incomplete = red, completed = green !!FOR BUG-FINDING/FIXING ONLY!! */
-  /*
-  input:invalid {
-    background-color: rgb(230, 179, 179);
-  }
-  input:placeholder-shown {
-    background-color: rgb(230, 179, 179);
-  }
-  input:valid {
-    background-color: rgb(179, 230, 179);
-  }
-  input.noValue {
-    background-color: rgb(230, 179, 179);
-  }
-  */
-/* Adjust navbar for screensize */
-  @media screen and (max-width: 1200px) {
-    #demoNavBar a {
-      font-size: 13px;
-      padding: 10px;
-    }
-  }
-  @media screen and (max-width: 840px) {
-    #demoNavBar a {
-      font-size: 10px;
-      padding: 7px;
-    }
-  }
-  /* 650px is when PS stops scaling the page  */
-  @media screen and (max-width: 650px) {
-    #demoNavBar a {
-      line-height: 1.5em;
-      font-size: 7px;
-      padding: 3px;
-    }
-  }
-  /* Maybe should change this to move links to a drop-down? */
-  @media screen and (max-width: 460px) {
-    #demoNavBar a {
-      font-size: 5px;
-      line-height: 1.5em;
-      padding: 2px;
-    }
-  }
-  
-/* Slide-down navigation bar for section anchors */
-  #demoNavBar {
-    position: fixed;
-    top: -100px;
-    width: 100%;
-    transition: top 0.3s;
-    overflow: hidden;
-    background-color: #333;
-    z-index: 1;
-  }
-  #demoNavBar a {
-    float: left;
-    display: block;
-    color: #f2f2f2;
-    text-align: center;
-    padding: 15px;
-    text-decoration: none;
-    font-size: 17px;
-  }
-  #demoNavBar a:hover {
-    background-color: #ddd;
-    color: black;
-  }
-  #demoNavBar a.active {
-    background-color: #04AA6D;
-    color: white;
-  }
-
-  #navToggleBox {
-    position: fixed;
-    top: -50px;
-    right: 50%;
-    width: 5%;
-    transition: top 0.2s ease 0.1;
-    overflow: hidden;
-    background-color: #333;
-    z-index: 1;
-  }
-  #navToggleBox a {
-    float: left;
-    display: block;
-    color: #f2f2f2;
-    text-align: center;
-    padding: 10px;
-    text-decoration: none;
-    font-size: 17px;
-  }
-  #navToggleBox a:hover {
-    background-color: #ddd;
-    color: black;
-  }
-  #navToggleBox a.active {
-    background-color: #04AA6D;
-    color: white;
-  }
-  #navToggleBox button {
-    float: left;
-    padding: 0px;
-    margin: 0px 0px 5px 12.5px;
-    line-height: 0.8em;
-  }
-  
-/* Make read-only inputs look normal */
-  input:read-only {
-    border-style: inset;
-    border-width: 2px;
-    border-color: rgb(118,118,118) rgb(133,133,133) rgb(133,133,133) rgb(118,118,118);
-    padding: 3px;
-    background-color: rgb(255,255,255);
-    /*background-color: rgb(217,217,217); /* highlight custom fields grey !!FOR BUG-FINDING/FIXING ONLY!! */
-  }
-  
-  input:only-child { width: 99%; }
-  
-  .editButton { float: right; }
-  
-  #editStateIncludeBtn { margin-top: 0px; }
-  
-  #stateIncludeBox {
-    margin-left: 0px;
-    margin-right: 0px;
-    margin-bottom: 0px;
-  }
-  
-  #demoContactsTable { border-style: none; }
-  #studentContactsTable { width: calc(100% - 20px); }
-</style>
+<link rel="stylesheet" type="text/css" href="/admin/styles/LPSGDC.css"></style>
 <!--
   NOTES:
   - In order to save input to database, <input> needs
@@ -158,14 +26,7 @@
     <a href="javascript:void(0);" id="collapseAll">Collapse All</a>
   </nav>
   <div id="navToggleBox">
-    <button type="button" width="50%"><a href="javascript:void(0);" id="toggleNavBar">&#x1f845;</a></button>
-  </div>
-  <div id="demoStyleOptions">
-    <label for="demoViewStyles" id="viewLabel" style="margin-left: 2em">View Style: </label>
-    <select id="demoViewStyles">
-      <option value="Collapse" selected>Collapsed (default)</option>
-      <option value="Tab">Tabs</option>
-    </select>
+    <button type="button"><a href="javascript:void(0);" id="toggleNavBar">&#x1f845;</a></button>
   </div>
   <div class="tabs" id="demoNavTabs">
     <ul>
@@ -203,40 +64,40 @@
             stu.student_number = ~([Students]student_number)]~(email)[/tlist_sql]"
           class="psTextWidget" readonly />
         </td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/emailconfig.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/emailconfig.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>-->
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
       <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Needs to be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trRace_Military" class="row-ethRace ethrace-other"> <!-- DOE029 -->
         <td class="bold">Family Military Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]MilitaryStatus" id="fieldMilitaryStatus" value="~(MilitaryStatus)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#militaryStatus'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#militaryStatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
     <!--  Custom Fields: 'Office Data' -->
       <tr id="trOffice_EntryDate" class="row-office office-general">
         <td class="bold">District Entry Date &tilde;</td>
         <td width="75%"><input type="text" name="[Students]DistrictEntryDate" id="fieldEntryDate" value="~(DistrictEntryDate)" placeholder="~[short.date]" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=~(frn)#dp1626705387672" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=~(frn)#dp1626705387672" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOffice_EntryGrade" class="row-office office-general">
         <td class="bold">District Entry Grade &tilde;</td> <!-- Auto-formatting makes this want a number, so translating it to K/PK might cause issues?   -->
         <td width="75%"><input type="text" name="[Students]DistrictEntryGradeLevel" id="fieldEntryGrade" value="~(DistrictEntryGradeLevel)" class="psTextWidget" readonly /></td>
         <!-- Entry Grade has no ID to link to on target page so linking to Entry Date which is directly above it -->
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=~(frn)#dp1626705387672" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=~(frn)#dp1626705387672" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOffice_SchoolCode" class="row-office office-general">
         <td class="bold">School Code &tilde;</td> <!-- DOE015 *code = 0000000[1,2] for SPED (1:gradeLvl >12 or private preschool), (2:homeschooled) -->
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]OverrideSchoolCode" id="fieldSchoolCode" value="~(OverrideSchoolCode)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_SchoolCode'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_SchoolCode'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOffice_ELCode" class="row-office office-el"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
         <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]EL" id="fieldELCode" value="~(EL)" placeholder="EL CODE ###..." class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/ellsims.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/ellsims.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOffice_FLEPDate" class="row-office office-el">
         <td class="bold">FLEP Date &tilde;</td> <!-- BUG: For some reason '~[short.date]' returns 'MM/DD/YYYY' here but gives the actual date in #fieldGradDate (I think because gradDate is a custom value) -->
@@ -245,12 +106,12 @@
       <tr id="trOffice_SPEDCode" class="row-office office-sped"> <!-- -->
         <td class="bold">SPED Code &tilde;</td>
         <td width="75%"><input type="text" name="[Students.U_Students_Extension]SPED" id="fieldSPEDCode" value="~(SPED)" placeholder="SPED CODE ###..." class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/spe.html?frn=~(frn)'" class="editButton" type="button">View</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/spe.html?frn=~(frn)'" class="editButton" type="button">View</button></td>-->
       </tr>
       <tr id="trOffice_504Plan" class="row-office office-sped">
         <td class="bold">504 Plan &tilde;</td> <!-- DOE039-->
         <td width="75%"><input type="text" name="[Students.S_MA_STU_SPED_X]Sec504PlanStatus" id="field504Plan" value="~(Sec504PlanStatus)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_504PlanStatus'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_504PlanStatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
     <!--  Custom Fields: 'Graduation Info' -->
       <tr id="trGrad_Date" class="row-grad">
@@ -264,7 +125,7 @@
       <tr id="trGrad_Plan" class="row-grad"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
         <td class="bold">Post-Graduation Plan &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]PostGradPlans" id="fieldGradPlan" value="~(PostGradPlans)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#futureplans'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#futureplans'" class="editButton" type="button">Edit</button></td>-->
          <!-- DEPENDENCIES: If...
               ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate)
               ...DOE033 does not = '500', then DOE12 must = '04', '10'(Certificate), or '11'(Completed Grade 12) -->
@@ -272,7 +133,7 @@
       <tr id="trGrad_CoreCompletion" class="row-grad"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
         <td class="bold">Massachusetts Core Curriculum Completion &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]GradCompleteCoreCurriculum" id="fieldCoreCompletion" value="~(GradCompleteCoreCurriculum)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#gradstatus'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#gradstatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
     <!-- Custom Fields: 'Legal Info' -->
       <tr id="trLegal_FullName" class="row-legal">
@@ -289,7 +150,7 @@
         <td class="bold">Legal Gender &tilde;</td>
         <td width="75%"><input type="text" name="[Students]Gender" id="fieldLegalGender" value="~(gender)" class="psTextWidget" readonly /></td>
         <!-- Gender on SIMS page doesn't have an ID to link to, should figure out how to get link to focus on it -->
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#'" class="editButton" type="button">Edit</button></td>-->
       </tr>
     <!-- Custom Fields: 'Other' (LPS)  -->
       <tr id="trOther_NCLB" class="row-other other-lps"> <!-- DOE020(?) *DOE020 is for 'Title 1 participation type', this is 'Title 1 School Choice status'. Don't know what the difference is. -->
@@ -299,32 +160,32 @@
       <tr id="trOther_FirstYearEL" class="row-other other-lps"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
         <td class="bold">First Year English Learner &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEP1stYrInUS" id="fieldFirstYearEL" value="~(LEP1stYrInUS)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_LEPinUS'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_LEPinUS'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_IsEL" class="row-other other-lps"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
         <td class="bold">English Learner &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency" id="fieldIsEL" value="~(LimitedEnglishProficiency)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_EngProficiency'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_EngProficiency'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_ELStatus" class="row-other other-lps"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
         <td class="bold">EL Program Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEPProgramStatus" id="fieldELStatus" value="~(LEPProgramStatus)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#BilingualStatus'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#BilingualStatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_SASID" class="row-other other-lps"> <!-- DOE002 *10 digits long, -->
         <td class="bold">State Assigned Student Identifier (SASID) &tilde;</td>
         <td width="75%"><input type="text" name="[Students]State_StudentNumber" id="fieldSASID" value="~(State_StudentNumber)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_IsImmigrant" class="row-other other-lps"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
         <td class="bold">Immigrant &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]ImmigrantStatus" id="fieldImmigrantStatus" value="~(ImmigrantStatus)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_ImmgrStatus'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_ImmgrStatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_EnrollmentStatus" class="row-other other-lps"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
         <td class="bold">Enrollment Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]EnrollStatusTimeOfCollection" id="fieldEnrollmentStatus" value="~(EnrollStatusTimeOfCollection)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#enrollstatus'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#enrollstatus'" class="editButton" type="button">Edit</button></td>-->
       <tr id="trOther_TransferFrom" class="row-other other-lps">
         <td class="bold">Transferring from &tilde;</td>
         <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" class="psTextWidget" readonly /></td>
@@ -336,7 +197,7 @@
       <tr id="trOther_OriginCountry" class="row-other other-lps"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
         <td class="bold">Country of Origin &tilde;</td> <!-- value="500" > not an immigrant student (US Origin) -->
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]CountryOfOrigin" id="fieldOriginCountry" value="~(CountryOfOrigin)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_Country'" class="editButton" type="button">Edit</button></td>
+        <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_Country'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_TeamFlag" class="row-other other-lps">
         <td class="bold">Team Flag &tilde;</td>
@@ -348,7 +209,7 @@
   <!-- Grouping these 3 fields in a box-round to communicate that the "Edit" button functions the same for each -->
   <div id="stateIncludeWrapper" class="row-ethRace ethrace-other">
     <div class="button-row" style="margin:0px;padding-bottom:0px;">
-      <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/stateMA.html?frn=~(frn)'" id="editStateIncludeBtn" type="button">Edit</button>
+      <!--<button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/stateMA.html?frn=~(frn)'" id="editStateIncludeBtn" type="button">Edit</button>-->
     </div>
     <div class="box-round" id="stateIncludeBox">
       <table class="linkDescList" style="margin-top:0px;width:100%;">
@@ -390,7 +251,7 @@
         <input type="checkbox" id="showAllChkBox" data-ng-disabled="!demoContext.hasEndDateAccess" data-ng-model="context.showAllStudentContacts" 
                data-ng-change="saveShowAllStudentContacts()" />
         <label for="showAllChkBox" data-ng-bind="getShowAllStudentContactsMessageWithCount()"></label>
-        <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/contacts.html?frn=~(frn)'" id="viewContactsBtn" type="button">View Contacts Page</button>
+        <!--<button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/contacts.html?frn=~(frn)'" id="viewContactsBtn" type="button">View Contacts Page</button>-->
         <!-- ~ "Add" button has been removed for Demographics ~ -->
       </div>
       <p class="feedback-info" data-ng-if="!context.contacts.length" >This student does not have any associated contacts.</p>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -1,37 +1,65 @@
 <!-- use jQuery to replace text -->
 <script src="/admin/javascript/LPSGDC.js"></script>
 <style type="text/css">
-#demo-navbar {
-  overflow: hidden;
-  background-color: #333; /* will likely be changing this */
-  position: fixed;
-  top: -100px;
-  width: 100%;
-  transition: top 0.3s;
-  z-index: 1;
-}
+  /* Slide-down navigation bar for section anchors */
+  #demo-navbar {
+    overflow: hidden;
+    background-color: #333;
+    position: fixed;
+    top: -100px;
+    width: 100%;
+    transition: top 0.3s;
+    z-index: 1;
+  }
+  #demo-navbar a {
+    float: left;
+    display: block;
+    color: #f2f2f2;
+    text-align: center;
+    padding: 15px;
+    text-decoration: none;
+    font-size: 17px;
+  }
+  #demo-navbar a:hover {
+    background-color: #ddd;
+    color: black;
+  }
+  #demo-navbar a.active {
+    background-color: #04AA6D;
+    color: white;
+  }
 
-#demo-navbar a {
-  float: left;
-  display: block;
-  color: #f2f2f2;
-  text-align: center;
-  padding: 15px;
-  text-decoration: none;
-  font-size: 17px;
-}
+  input:read-only {
+    border-style: inset;
+    border-width: 2px; 
+    border-color: rgb(118,118,118) rgb(133,133,133) rgb(133,133,133) rgb(118,118,118);
+    padding: 3px;
+    background-color: rgb(217,217,217); /* highlight custom fields grey */
+  }
 
-#demo-navbar a:hover {
-  background-color: #ddd;
-  color: black;
-}
-
-#demo-navbar a.active {
-  background-color: #04AA6D;
-  color: white;
-}
-
+  /* highlight fields: incomplete = red, completed = green */
+  input:invalid {
+    background-color: rgb(230, 179, 179);
+  }
+  input:placeholder-shown {
+    background-color: rgb(230, 179, 179);
+  }
+  input:valid {
+    background-color: rgb(179, 230, 179);
+  }
+  input.noValue {
+    background-color: rgb(230, 179, 179);
+  }
+  input:only-child {
+    width: 99%;
+  }
 </style>
+<!-- 
+  NOTES:
+   -Can either do fields as 'disabled' or 'readonly' 
+     *I think the main difference is how it looks but maybe it changes
+       submit funcitionality. Setting as 'readonly' for now
+ -->
 <div id="LPS-GDCustomhiddentable" style="display: none;">
   <nav id="demo-navbar"> <!-- Add contacts/legal sections when they are done -->
     <a href="#StudentSection" class="sectLink">Student</a>
@@ -48,17 +76,17 @@
   <table>
     <tbody>
     <!--  Custom Fields: 'Student Info' -->
-      <tr id="trStudent_Mobile">
-        <td class="bold">Student Mobile &tilde;</td>
-        <td><input type="text" id="fieldStudentMobile" name="[Students.U_Students_Extension]student_mobile" value="" size="17" placeholder="123-456-7890" readonly /></td>
+      <tr id="trStudent_Mobile" class="row-student student-contactInfo">
+        <td class="bold">Student Mobile &tilde;</td><!-- where is this info stored? -->
+        <td width="75%"><input type="tel" id="fieldStudentMobile" placeholder="123-456-7890" readonly /></td>
       </tr>
-      <tr id="trStudent_PersonalEmail">
+      <tr id="trStudent_PersonalEmail" class="row-student student-contactInfo">
         <td class="bold">Student Personal Email &tilde;</td>
-        <td><input type="text" id="fieldPersonalEmail" name="[Students.U_Students_Extension]student_personalemail" value="" size="50" placeholder="student@example.com" readonly /></td>
+        <td width="75%"><input type="email" id="fieldPersonalEmail" value="" placeholder="student@example.com" readonly /></td>
       </tr>
-      <tr id="trStudent_LPSEmail">
+      <tr id="trStudent_LPSEmail" class="row-student student-contactInfo">
         <td class="bold">Student LPS Email &tilde;</td>
-        <td><input type="text" id="fieldLPSEmail" value="~[tlist_sql; 
+        <td width="75%"><input type="email" id="fieldLPSEmail" value="~[tlist_sql; 
           SELECT psc.Email AS email
           FROM PSM_STudentcontact psc
             JOIN PSM_StudentContactType psct ON psc.StudentContactTypeId = psct.id
@@ -66,128 +94,142 @@
             JOIN SYNC_StudentMap ssm ON psc.StudentId = ssm.studentid
             JOIN Students stu ON ssm.studentsdcid = stu.dcid
           WHERE
-            stu.student_number = ~([Students]student_number)] ~(email)[/tlist_sql]"
-          readonly size="50" />
+            stu.student_number = ~([Students]student_number)]~(email)[/tlist_sql]"
+          readonly />
         </td>
       </tr>
+    <!--  Custom Fields: 'Guardian/Contacts Information' -->
+      <tr id="trContacts_">
+        
+      </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
-      <tr id="trRace_ExcludeState">
+      <tr id="trRace_ExcludeState" class="row-ethRace ethrace-other">
         <td class="bold">Exclude from State Reporting? &tilde;</td>
-        <td><input type="text" id="fieldExcludeState" value="~([Students]State_ExcludeFromReporting)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldExcludeState" value="~([Students]State_ExcludeFromReporting)" readonly /></td>
       </tr>
-      <tr id="trRace_IncludeSIMS">
+      <tr id="trRace_IncludeSIMS" class="row-ethRace ethrace-other">
         <td class="bold">Include in SIMS Report? &tilde;</td>
-        <td><input type="text" id="fieldIncludeSIMS" value="~([Students.S_MA_STU_SIMS_X]IncludeInSIMSInd)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldIncludeSIMS" value="~([Students.S_MA_STU_SIMS_X]IncludeInSIMSInd)" readonly /></td>
       </tr>
-      <tr id="trRace_IncludeSASID">
+      <tr id="trRace_IncludeSASID" class="row-ethRace ethrace-other">
         <td class="bold">Include in SASID Report? &tilde;</td>
-        <td><input type="text" id="fieldIncludeSASID" value="~([Students.S_MA_STU_X]IncludeInSASIDMSRInd)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldIncludeSASID" value="~([Students.S_MA_STU_X]IncludeInSASIDMSRInd)" readonly /></td>
       </tr>
-      <tr id="trRace_BirthCity"> <!-- DOE008 *Needs to be converted to town code -->
+      <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Needs to be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
-        <td><input type="text" id="fieldBirthCity" value="~([Students.S_MA_STU_Demographic_X]BirthCity)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldBirthCity" value="~([Students.S_MA_STU_Demographic_X]BirthCity)" readonly /></td>
       </tr>
-      <tr id="trRace_Military"> <!-- DOE029 -->
+      <tr id="trRace_Military" class="row-ethRace ethrace-other"> <!-- DOE029 -->
         <td class="bold">Family Military Status &tilde;</td>
-        <td><input type="text" id="fieldMilitaryStatus" value="~([Students.S_MA_STU_X]MilitaryStatus)" size="80" readonly /></td>
+        <td width="75%"><input type="text" id="fieldMilitaryStatus" value="~([Students.S_MA_STU_X]MilitaryStatus)" readonly /></td>
       </tr>
     <!--  Custom Fields: 'Office Data' -->
-      <tr id="trOffice_EntryDate">
-        <td class="bold">District Entry Date</td>
-        <td><input type="text" id="fieldEntryDate" value="~([Students]DistrictEntryDate)" readonly /></td>
+      <tr id="trOffice_EntryDate" class="row-office office-general">
+        <td class="bold">District Entry Date &tilde;</td>
+        <td width="75%"><input type="text" id="fieldEntryDate" value="~([Students]DistrictEntryDate)" readonly /></td>
       </tr>
-      <tr id="trOffice_EntryGrade">
-        <td class="bold">District Entry Grade &tilde;</td>
-        <td><input type="text" id="fieldEntryGrade" value="~([Students]DistrictEntryGradeLevel)" readonly /></td>
+      <tr id="trOffice_EntryGrade" class="row-office office-general">
+        <td class="bold">District Entry Grade &tilde;</td> <!-- might change to text input, don't know if uses '-2' or 'PK' for pre-school value   -->
+        <td width="75%"><input type="number" id="fieldEntryGrade" value="~([Students]DistrictEntryGradeLevel)" min="-2" max="13" readonly /></td>
       </tr>
-      <tr id="trOffice_SchoolCode">
+      <tr id="trOffice_SchoolCode" class="row-office office-general">
         <td class="bold">School Code &tilde;</td> <!-- DOE015 *code = 0000000[1,2] for SPED (1:gradeLvl >12 or private preschool), (2:homeschooled) -->
-        <td><input type="text" id="fieldSchoolCode" value="~([Students.S_MA_STU_X]OverrideSchoolCode)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldSchoolCode" value="~([Students.S_MA_STU_X]OverrideSchoolCode)" readonly /></td>
       </tr>
-      <tr id="trOffice_ELCode"> <!-- DOE027 or 24? maybe 41? -->
+      <tr id="trOffice_ELCode" class="row-office office-el"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
-        <td><input type="text" id="fieldELCode" value="~([Students.U_Def_Ext_Students]EL)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldELCode" value="~([Students.U_Def_Ext_Students]EL)" placeholder="EL CODE ###..." readonly /></td>
       </tr>
-      <tr id="trOffice_FLEPDate">
+      <tr id="trOffice_FLEPDate" class="row-office office-el">
         <td class="bold">FLEP Date &tilde;</td>
-        <td><input type="text" id="fieldFLEPDate" value="~([Students.U_Def_Ext_Students]FLEPDate)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldFLEPDate" value="~([Students.U_Def_Ext_Students]FLEPDate)" placeholder="01/01/1999" readonly /></td><!-- placeholder doesnt seem to work for dates -->
       </tr>
-      <tr id="trOffice_SPEDCode"> <!-- DOE032, 34, 36, 38, or 40? -->
+      <tr id="trOffice_SPEDCode" class="row-office office-sped"> <!-- DOE032, 34, 36, 38, or 40? -->
         <td class="bold">SPED Code &tilde;</td>
-        <td><input type="text" id="fieldSPEDCode" value="~([Students.U_Students_Extension]SPED)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldSPEDCode" value="~([Students.U_Students_Extension]SPED)" placeholder="SPED CODE ###..." readonly /></td>
       </tr>
-      <tr id="trOffice_504Plan">
+      <tr id="trOffice_504Plan" class="row-office office-sped">
         <td class="bold">504 Plan &tilde;</td> <!-- DOE039-->
-        <td><input type="text" id="field504Plan" value="~([Students.S_MA_STU_SPED_X]Sec504PlanStatus)" size="80" readonly /></td>
+        <td width="75%"><input type="text" id="field504Plan" value="~([Students.S_MA_STU_SPED_X]Sec504PlanStatus)" readonly /></td>
       </tr>
     <!--  Custom Fields: 'Graduation Info' -->
-      <tr id="trGrad_Date">
+      <tr id="trGrad_Date" class="row-grad">
         <td class="bold">Graduation Date &tilde;</td>
-        <td><input type="text" id="fieldGradDate" value="~([Students.U_StudentsUserFields]Grad_Date)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldGradDate" value="~([Students.U_StudentsUserFields]Grad_Date)" placeholder="01/01/1999" readonly /></td><!-- placeholder doesnt seem to work for dates -->
       </tr>
-      <tr id="trGrad_Cohort">
+      <tr id="trGrad_Cohort" class="row-grad">
         <td class="bold">DESE Cohort &tilde;</td>  <!-- Dont know what the cohort options are, could maybe be better as a dropdown? -->
-        <td><input type="text" id="fieldCohort" value="~([Students.U_Def_Ext_Students]cohort)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldCohort" value="~([Students.U_Def_Ext_Students]cohort)" placeholder="COHORT #..." readonly /></td>
       </tr>
-      <tr id="trGrad_Plan"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
+      <tr id="trGrad_Plan" class="row-grad"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
         <td class="bold">Post-Graduation Plan &tilde;</td> 
-        <td><input type="text" id="fieldGradPlan" value="~([Students.S_MA_STU_X]PostGradPlans)" size="80" readonly /></td>
+        <td width="75%"><input type="text" id="fieldGradPlan" value="~([Students.S_MA_STU_X]PostGradPlans)" readonly /></td>
          <!-- DEPENDENCIES: If... 
               ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate)
               ...DOE033 does not = '500', then DOE12 must = '04', '10'(Certificate), or '11'(Completed Grade 12) -->
       </tr>
-      <tr id="trGrad_CoreCompletion"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
+      <tr id="trGrad_CoreCompletion" class="row-grad"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
         <td class="bold">Massachusetts Core Curriculum Completion &tilde;</td>
-        <td><input type="text" id="fieldCoreCompletion" value="~([Students.S_MA_STU_X]GradCompleteCoreCurriculum)" size="80" readonly /></td>
+        <td width="75%"><input type="text" id="fieldCoreCompletion" value="~([Students.S_MA_STU_X]GradCompleteCoreCurriculum)" readonly /></td>
       </tr>
-      <!-- Custom Fields: 'Other' (Built-In) -->
-      <tr id="trOther_NCLB"> <!-- DOE020(?) *DOE020 is for 'Title 1 participation type', this is 'Title 1 School Choice status'. Don't know what the difference is. -->
-        <td class="bold">NCLB/Title 1 School Choice &tilde;</td>
-        <td><input type="text" id="fieldNCLB" value="~([Students.S_MA_STU_SIMS_X]Title1SchoolChoice)" readonly /></td>
+    <!-- Custom Fields: 'Legal Info' -->
+      <tr id="trLegal_FullName" class="row-legal">
+        <td class="bold">Legal Name (Last, First Middle Suffix) &tilde;</td>
+        <td width="75%">
+          <input type="text" id="fieldLegalLast_temp" value="~([Students.StudentCoreFields]PSCore_Legal_Last_Name)" style="width:35%" placeholder="SMITH..." readonly /> ,
+          <input type="text" id="fieldLegalFirst_temp" value="~([Students.StudentCoreFields]PSCore_Legal_First_Name)" style="width:35%" placeholder="JOHN..." readonly />
+          <input type="text" id="fieldLegalMiddle_temp" value="~([Students.StudentCoreFields]PSCore_Legal_Middle_Name)" style="width:15%" placeholder="WILLIAM..." readonly />
+          <input type="text" id="fieldLegalSuffix_temp" value="~([Students.StudentCoreFields]PSCore_Legal_Suffix)" style="width:15%" placeholder="Sr., Jr., III, etc..." readonly />
+          <button type="button" onclick="StudentCoreLegalModule.copyToLegalNameFields('lastName', 'firstName', 'middleName', 'fieldLegalLast_temp', 'fieldLegalFirst_temp', 'fieldLegalMiddle_temp', 'fieldLegalSuffix_temp');">Copy</button>
+        </td>
       </tr>
-      <tr id="trOther_GradeLvl"> <!-- DOE016 -->
-        <td class="bold">Current Grade Level &tilde;</td>
-        <td><input type="text" id="fieldGradeLvl" value="~([Students]Grade_Level)" readonly /></td>
+      <tr id="trLegal_Gender" class="row-legal">
+        <td class="bold">Legal Gender &tilde;</td>
+        <td width="75%"><input type="text" id="fieldLegalGender" value="~([Students]Gender)" readonly /></td>
       </tr>
     <!-- Custom Fields: 'Other' (LPS)  -->
-      <tr id="trOther_FirstYearEL"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
+      <tr id="trOther_NCLB" class="row-other other-lps"> <!-- DOE020(?) *DOE020 is for 'Title 1 participation type', this is 'Title 1 School Choice status'. Don't know what the difference is. -->
+        <td class="bold">NCLB/Title 1 School Choice &tilde;</td>
+        <td width="75%"><input type="text" id="fieldNCLB" value="~([Students.S_MA_STU_SIMS_X]Title1SchoolChoice)" readonly /></td>
+      </tr>
+      <tr id="trOther_FirstYearEL" class="row-other other-lps"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
         <td class="bold">First Year English Learner &tilde;</td>
-        <td><input type="text" id="fieldFirstYearEL" value="~([Students.S_MA_STU_Demographic_X]LEP1stYrInUS)" size="80" readonly /></td>
+        <td width="75%"><input type="text" id="fieldFirstYearEL" value="~([Students.S_MA_STU_Demographic_X]LEP1stYrInUS)" readonly /></td>
       </tr>
-      <tr id="trOther_IsEL"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
+      <tr id="trOther_IsEL" class="row-other other-lps"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
         <td class="bold">English Learner &tilde;</td>
-        <td><input type="text" id="fieldIsEL" value="~([Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldIsEL" value="~([Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency)" readonly /></td>
       </tr>
-      <tr id="trOther_ELStatus"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
+      <tr id="trOther_ELStatus" class="row-other other-lps"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
         <td class="bold">EL Program Status &tilde;</td>
-        <td><input type="text" id="fieldELStatus" value="~([Students.S_MA_STU_Demographic_X]LEPProgramStatus)" size="80" readonly /></td>
+        <td width="75%"><input type="text" id="fieldELStatus" value="~([Students.S_MA_STU_Demographic_X]LEPProgramStatus)" readonly /></td>
       </tr>
-      <tr id="trOther_SASID"> <!-- DOE002 *10 digits long, -->
+      <tr id="trOther_SASID" class="row-other other-lps"> <!-- DOE002 *10 digits long, -->
         <td class="bold">State Assigned Student Identifier (SASID) &tilde;</td>
-        <td><input type="text" id="fieldSASID" value="~([Students]State_StudentNumber)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldSASID" value="~([Students]State_StudentNumber)" readonly /></td>
       </tr>
-      <tr id="trOther_IsImmigrant"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
+      <tr id="trOther_IsImmigrant" class="row-other other-lps"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
         <td class="bold">Immigrant &tilde;</td>
-        <td><input type="text" id="fieldImmigrantStatus" value="~([Students.S_MA_STU_Demographic_X]ImmigrantStatus)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldImmigrantStatus" value="~([Students.S_MA_STU_Demographic_X]ImmigrantStatus)" readonly /></td>
       </tr>
-      <tr id="trOther_EnrollmentStatus"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
+      <tr id="trOther_EnrollmentStatus" class="row-other other-lps"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
         <td class="bold">Enrollment Status &tilde;</td>
-        <td><input type="text" id="fieldEnrollmentStatus" value="~([Students.S_MA_STU_X]EnrollStatusTimeOfCollection)" size="80" readonly /></td>
-      <tr id="trOther_TransferFrom">
+        <td width="75%"><input type="text" id="fieldEnrollmentStatus" value="~([Students.S_MA_STU_X]EnrollStatusTimeOfCollection)" readonly /></td>
+      <tr id="trOther_TransferFrom" class="row-other other-lps">
         <td class="bold">Transferring from &tilde;</td>
-        <td><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="School Name" readonly /></td>
+        <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" readonly /></td>
       </tr>
-      <tr id="trOther_BirthState"> 
+      <tr id="trOther_BirthState" class="row-other other-lps"> 
         <td class="bold">Birth State &tilde;</td>
-        <td><input type="text" id="fieldBirthState" value="~([Students.U_StudentsUserFields]MA_BirthState)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldBirthState" value="~([Students.U_StudentsUserFields]MA_BirthState)" readonly /></td>
       </tr>
-      <tr id="trOther_OriginCountry"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
+      <tr id="trOther_OriginCountry" class="row-other other-lps"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
         <td class="bold">Country of Origin &tilde;</td> <!-- value="500" > not an immigrant student (US Origin) -->
-        <td><input type="text" id="fieldOriginCountry" value="~([Students.S_MA_STU_Demographic_X]CountryOfOrigin)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldOriginCountry" value="~([Students.S_MA_STU_Demographic_X]CountryOfOrigin)" readonly /></td>
       </tr>
-      <tr id="trOther_TeamFlag">
+      <tr id="trOther_TeamFlag" class="row-other other-lps">
         <td class="bold">Team Flag &tilde;</td>
-        <td><input type="text" id="fieldTeamFlag" value="~([Students.U_StudentsUserFields]TeamFlag)" readonly /></td>
+        <td width="75%"><input type="text" id="fieldTeamFlag" value="~([Students.U_StudentsUserFields]TeamFlag)"  placeholder="TEAM FLAG..." readonly /></td>
       </tr>
     </tbody>
   </table>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -63,7 +63,16 @@
       <tr id="trfieldStudent_LPSemail">
         <td class="bold">Student LPS Email &tilde;</td>
         <td>  <!-- Can probably just have them enter the first part and make the '@student.lawrence.k12.ma.us' part automatic -->
-          ~([01]student_number)@students.lawrence.k12.ma.us
+          ~[tlist_sql; SELECT
+            psc.email AS email
+          FROM
+            PSM_STudentcontact psc
+            JOIN psm_studentcontacttype psct ON psc.studentcontacttypeid = psct.id
+              AND psct.name = 'Self'
+            JOIN sync_studentmap ssm ON psc.studentid = ssm.studentid
+            JOIN students stu ON ssm.studentsdcid = stu.dcid
+          WHERE
+            stu.student_number =~([01]student_number)]~(email)[/tlist_sql]
         </td>
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
@@ -147,7 +156,6 @@
       <tr id="trfieldELCode"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
         <td>
-          ~(students.u_def_ext_students.el)
           <input type="text" id="fieldELCode" name="[Students.U_Students_Extension]office_elcode" value="" size="8" placeholder="1234567890">
         </td>
       </tr>
@@ -189,7 +197,6 @@
       <tr id="trfieldCohort">
         <td class="bold">DESE Cohort &tilde;</td>  <!-- Dont know what the cohort options are, could maybe be better as a dropdown? -->
         <td>
-          ~(students.u_def_ext_students.cohort)
           <input type="text" id="fieldCohort" name="[Students.U_Students_Extension]graduation_cohort" value="" size="5" placeholder="########"> 
         </td>
       </tr>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -63,7 +63,7 @@
       <tr id="trfieldStudent_LPSemail">
         <td class="bold">Student LPS Email &tilde;</td>
         <td>  <!-- Can probably just have them enter the first part and make the '@student.lawrence.k12.ma.us' part automatic -->
-          <input type="text" id="fieldStudent_LPSemail" name="[Students.U_Students_Extension]student_LPSemail" value="" size="50" placeholder="first.last@student.lawrence.k12.ma.us">
+          ~([01]student_number)@students.lawrence.k12.ma.us
         </td>
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
@@ -147,6 +147,7 @@
       <tr id="trfieldELCode"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
         <td>
+          ~(students.u_def_ext_students.el)
           <input type="text" id="fieldELCode" name="[Students.U_Students_Extension]office_elcode" value="" size="8" placeholder="1234567890">
         </td>
       </tr>
@@ -188,6 +189,7 @@
       <tr id="trfieldCohort">
         <td class="bold">DESE Cohort &tilde;</td>  <!-- Dont know what the cohort options are, could maybe be better as a dropdown? -->
         <td>
+          ~(students.u_def_ext_students.cohort)
           <input type="text" id="fieldCohort" name="[Students.U_Students_Extension]graduation_cohort" value="" size="5" placeholder="########"> 
         </td>
       </tr>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -22,8 +22,8 @@
     <a href="#LegalSection" class="sectLink">Legal</a>
     <a href="#OtherSection" class="sectLink">Other</a>
     <a href="#EverythingElseSection" class="sectLink">Everything Else</a>
-    <a href="javascript:void(0);" id="expandAll">Expand All</a>
-    <a href="javascript:void(0);" id="collapseAll">Collapse All</a>
+    <a href="javascript:void(0);" id="expandAll" class="sectLink">Expand All</a>
+    <a href="javascript:void(0);" id="collapseAll" class="sectLink">Collapse All</a>
   </nav>
   <div id="navToggleBox">
     <button type="button"><a href="javascript:void(0);" id="toggleNavBar">&#x1f845;</a></button>
@@ -67,7 +67,19 @@
         <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/emailconfig.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>-->
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
-      <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Needs to be converted to town code -->
+      <tr id="trRace_ExcludeState" class="row-ethRace ethrace-other">
+        <td class="bold">Exclude from State Reporting? &tilde;</td>
+        <td><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" class="psTextWidget" readonly /></td>
+      </tr>
+      <tr id="trRace_IncludeSIMS" class="row-ethRace ethrace-other">
+        <td class="bold">Include in SIMS Report? &tilde;</td>
+        <td><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)" class="psTextWidget" readonly /></td>
+      </tr>
+      <tr id="trRace_IncludeSASID" class="row-ethRace ethrace-other">
+        <td class="bold">Include in SASID Report? &tilde;</td>
+        <td><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)" class="psTextWidget" readonly /></td>
+      </tr>
+      <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Must be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>-->
@@ -186,6 +198,7 @@
         <td class="bold">Enrollment Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]EnrollStatusTimeOfCollection" id="fieldEnrollmentStatus" value="~(EnrollStatusTimeOfCollection)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#enrollstatus'" class="editButton" type="button">Edit</button></td>-->
+      </tr>
       <tr id="trOther_TransferFrom" class="row-other other-lps">
         <td class="bold">Transferring from &tilde;</td>
         <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" class="psTextWidget" readonly /></td>
@@ -205,35 +218,6 @@
       </tr>
     </tbody>
   </table>
-
-  <!-- Grouping these 3 fields in a box-round to communicate that the "Edit" button functions the same for each -->
-  <div id="stateIncludeWrapper" class="row-ethRace ethrace-other">
-    <div class="button-row" style="margin:0px;padding-bottom:0px;">
-      <!--<button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/stateMA.html?frn=~(frn)'" id="editStateIncludeBtn" type="button">Edit</button>-->
-    </div>
-    <div class="box-round" id="stateIncludeBox">
-      <table class="linkDescList" style="margin-top:0px;width:100%;">
-        <colgroup>
-          <col style="width: auto">
-          <col style="width: 100%">
-        </colgroup>
-        <tbody width="100%">
-          <tr id="trRace_ExcludeState" class="">
-            <td class="bold">Exclude from State Reporting? &tilde;</td>
-            <td><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" class="psTextWidget" readonly /></td>
-          </tr> <!-- All "include/exclude" fields are in the same place so only need one edit button link -->
-          <tr id="trRace_IncludeSIMS" class="">
-            <td class="bold">Include in SIMS Report? &tilde;</td>
-            <td><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)" class="psTextWidget" readonly /></td>
-          </tr>
-          <tr id="trRace_IncludeSASID" class="">
-            <td class="bold">Include in SASID Report? &tilde;</td>
-            <td><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)" class="psTextWidget" readonly /></td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
       
   <!--
     Copying Contacts page source and displaying it in Demographics 'Contacts' section.
@@ -404,92 +388,30 @@
     </div>
     <script> var _curSchoolNumber = 0; </script>
     <div class="hidden">
-      <input id="studentDcid" type="hidden" value="113601" />
-      <input id="schoolId" type="hidden" value="0" />
-      <input id="studentNumber" type="hidden" value="111308" />
+      <input id="studentDcid" type="hidden" value="~(rn)" />
+      <input id="schoolId" type="hidden" value="~(OverrideSchoolCode)" />
+      <input id="studentNumber" type="hidden" value="~(rn)" />
     </div>
   </div>
 
   <!-- Comment Form -->
   <div class="box-round" id="demoComments">
-    <div class="tlistCollectionTable tlistCollectionTableInitialized">
-      <div class="button-row">
-        <button type="button" id="addButton">Add</button>
-      </div>
-      <table class="grid">
-        <colgroup>
-          <col class="col-COMMENT_DATE">
-          <col class="col-COMMENT_REASON">
-          <col class="col-COMMENT_PERSON">
-          <col class="col-COMMENT_COMMENT">
-          <col class="col-delete">
-        </colgroup>
-        <thead>
-          <tr>
-            <th>Date of Comment</th>
-            <th>Reason for Comment</th>
-            <th>Person Making Change</th>
-            <th>Comment</th>
-            <th>Delete</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr id="rowId_52412">
-            <td id="COMMENT_DATE_52412" class="td-COMMENT_DATE">
-              <b class="dpWrapper">
-                <input type="text" class="COMMENT_DATE psDateWidget unvalidated hasDatepicker" value="03/26/2019"
-                       data-validation="{&quot;type&quot;:&quot;date&quot;,&quot;key&quot;:&quot;students.u_comment.comment_date&quot;}"
-                       name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:52412]COMMENT_DATE$format=date" data-key="students.u_comment.comment_date" id="dp1625588312868" placeholder="MM/DD/YYYY">
-                <button type="button" class="ui-datepicker-trigger" aria-hidden="true" tabindex="-1"></button>
-              </b>
-            </td>
-            <td id="COMMENT_REASON_52412" class="td-COMMENT_REASON">
-              <input type="text" class="COMMENT_REASON psTextWidget" value="TransferFrom-Original" maxlength="25"
-                     data-validation="{&quot;maxlength&quot;:&quot;25&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_reason&quot;}"
-                     name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:52412]COMMENT_REASON" data-key="students.u_comment.comment_reason" id="ldv_generatedID1">
-            </td>
-            <td id="COMMENT_PERSON_52412" class="td-COMMENT_PERSON">
-              <input type="text" class="COMMENT_PERSON psTextWidget unvalidated" value="DC" maxlength="2"
-                     data-validation="{&quot;maxlength&quot;:&quot;2&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_person&quot;}"
-                     name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:52412]COMMENT_PERSON" data-key="students.u_comment.comment_person">
-            </td>
-            <td id="COMMENT_COMMENT_52412" class="td-COMMENT_COMMENT">
-              <input type="text" class="COMMENT_COMMENT psTextWidget unvalidated" value="GLCA" maxlength="500"
-                     data-validation="{&quot;maxlength&quot;:&quot;500&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_comment&quot;}"
-                     name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:52412]COMMENT_COMMENT" data-key="students.u_comment.comment_comment">
-            </td>
-            <td>
-              <input class="deleteCB hide" name="DC-STUDENTS:113601.U_COMMENT.U_COMMENT:52412" type="checkbox">
-              <button class="undoDelRow hide" type="button"><em>&nbsp;</em></button>
-              <button class="deleteRow" type="button"><em>&nbsp;</em></button>
-            </td>
-          </tr>
-          <tr class="new">
-            <td id="COMMENT_DATE_-{INSERT_COUNTER}" class="td-COMMENT_DATE">
-              <input type="text" class="COMMENT_DATE" data-addclass="psDateWidget" value=""
-                     data-validation-add="{&quot;type&quot;:&quot;date&quot;,&quot;key&quot;:&quot;students.u_comment.comment_date&quot;}"
-                     data-name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:-{INSERT_COUNTER}]COMMENT_DATE$format=date">
-            </td>
-            <td id="COMMENT_REASON_-{INSERT_COUNTER}" class="td-COMMENT_REASON">
-              <input type="text" class="COMMENT_REASON" data-addclass="psTextWidget" maxlength="25" value=""
-                     data-validation-add="{&quot;maxlength&quot;:&quot;25&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_reason&quot;}"
-                     data-name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:-{INSERT_COUNTER}]COMMENT_REASON">
-            </td>
-            <td id="COMMENT_PERSON_-{INSERT_COUNTER}" class="td-COMMENT_PERSON">
-              <input type="text" class="COMMENT_PERSON" data-addclass="psTextWidget" maxlength="2" value=""
-                     data-validation-add="{&quot;maxlength&quot;:&quot;2&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_person&quot;}"
-                     data-name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:-{INSERT_COUNTER}]COMMENT_PERSON">
-            </td>
-            <td id="COMMENT_COMMENT_-{INSERT_COUNTER}" class="td-COMMENT_COMMENT">
-              <input type="text" class="COMMENT_COMMENT" data-addclass="psTextWidget" maxlength="500" value=""
-                     data-validation-add="{&quot;maxlength&quot;:&quot;500&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_comment&quot;}"
-                     data-name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:-{INSERT_COUNTER}]COMMENT_COMMENT">
-            </td>
-            <td class="deleteCol"></td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    ~[tlist_child:STUDENTS.U_COMMENT.U_COMMENT;displaycols:COMMENT_DATE,COMMENT_REASON,COMMENT_PERSON,COMMENT_COMMENT;fieldNames:Date of Comment,Reason for Comment,Person Making Change,Comment;type:html]
+    <script>  
+      var InstValues= {};
+      InstValues[' ']='';
+      InstValues['REG']='Registration';
+      InstValues['COA']='Change of Address';
+      InstValues['PCU']='Program Code Updates';
+      InstValues['HOME']='Homeless';
+      InstValues['TF']='TransferFrom-Original';
+      InstValues['WD']='Withdrawal';
+      InstValues['GC']='Grade Change';
+      InstValues['RE']='Re-Engaged';
+      InstValues['Other']='Other';
+      //tlistText2DropDown('COMMENT_REASON',InstValues);
+    </script>
+    <!-- <div class="button-row"><input type="hidden" name="ac" value="prim">~[submitbutton]</div> -->
   </div>
   
 </div>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -48,367 +48,146 @@
   <table>
     <tbody>
     <!--  Custom Fields: 'Student Info' -->
-      <tr id="trfieldStudent_Mobile">
+      <tr id="trStudent_Mobile">
         <td class="bold">Student Mobile &tilde;</td>
-        <td>
-          <input type="text" id="fieldStudent_Mobile" name="[Students.U_Students_Extension]student_mobile" value="" size="17" placeholder="123-456-7890">
-        </td>
+        <td><input type="text" id="fieldStudentMobile" name="[Students.U_Students_Extension]student_mobile" value="" size="17" placeholder="123-456-7890" readonly /></td>
       </tr>
-      <tr id="trfieldStudent_Personalemail">
+      <tr id="trStudent_PersonalEmail">
         <td class="bold">Student Personal Email &tilde;</td>
-        <td>
-          <input type="text" id="fieldStudent_Personalemail" name="[Students.U_Students_Extension]student_personalemail" value="" size="50" placeholder="student@example.com">
-        </td>
+        <td><input type="text" id="fieldPersonalEmail" name="[Students.U_Students_Extension]student_personalemail" value="" size="50" placeholder="student@example.com" readonly /></td>
       </tr>
-      <tr id="trfieldStudent_LPSemail">
+      <tr id="trStudent_LPSEmail">
         <td class="bold">Student LPS Email &tilde;</td>
-        <td>  <!-- Can probably just have them enter the first part and make the '@student.lawrence.k12.ma.us' part automatic -->
-          ~[tlist_sql; SELECT
-	psc.email AS email
-FROM
-	PSM_STudentcontact psc
-	JOIN psm_studentcontacttype psct ON psc.studentcontacttypeid = psct.id
-	AND psct.name = 'Self'
-	JOIN sync_studentmap ssm ON psc.studentid = ssm.studentid
-	JOIN students stu ON ssm.studentsdcid = stu.dcid
-WHERE
-	stu.student_number =~([01]student_number)]~(email)[/tlist_sql]
+        <td><input type="text" id="fieldLPSEmail" value="~[tlist_sql; 
+          SELECT psc.Email AS email
+          FROM PSM_STudentcontact psc
+            JOIN PSM_StudentContactType psct ON psc.StudentContactTypeId = psct.id
+              AND psct.Name = 'Self'
+            JOIN SYNC_StudentMap ssm ON psc.StudentId = ssm.studentid
+            JOIN Students stu ON ssm.studentsdcid = stu.dcid
+          WHERE
+            stu.student_number = ~([Students]student_number)] ~(email)[/tlist_sql]"
+          readonly size="50" />
         </td>
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
-      <tr id="trcheckboxExcludeState">
+      <tr id="trRace_ExcludeState">
         <td class="bold">Exclude from State Reporting? &tilde;</td>
-        <td>
-          <input type="checkbox" id="radioExcludeState" name="[Students.U_Students_Extension]race_excludestate" value="no_State">
-        </td>
+        <td><input type="text" id="fieldExcludeState" value="~([Students]State_ExcludeFromReporting)" readonly /></td>
       </tr>
-      <tr id="trcheckboxIncludeSIMS">
+      <tr id="trRace_IncludeSIMS">
         <td class="bold">Include in SIMS Report? &tilde;</td>
-        <td>
-          <input type="checkbox" id="checkboxIncludeSIMS" name="[Students.U_Students_Extension]race_includesims" value="yes_SIMS">
-        </td>
+        <td><input type="text" id="fieldIncludeSIMS" value="~([Students.S_MA_STU_SIMS_X]IncludeInSIMSInd)" readonly /></td>
       </tr>
-      <tr id="trcheckboxIncludeSASID">
+      <tr id="trRace_IncludeSASID">
         <td class="bold">Include in SASID Report? &tilde;</td>
-        <td>
-          <input type="checkbox" id="checkboxIncludeSASID" name="[Students.U_Students_Extension]race_includesasid" value="yes_SASID">
-        </td>
+        <td><input type="text" id="fieldIncludeSASID" value="~([Students.S_MA_STU_X]IncludeInSASIDMSRInd)" readonly /></td>
       </tr>
-      <tr id="trfieldBirthCity"> <!-- DOE008 *Needs to be converted to town code -->
+      <tr id="trRace_BirthCity"> <!-- DOE008 *Needs to be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
-        <td>
-          <input type="text" id="fieldBirthCity" name="[Students.U_Students_Extension]race_birthcity" value="" size="20">
-        </td>
+        <td><input type="text" id="fieldBirthCity" value="~([Students.S_MA_STU_Demographic_X]BirthCity)" readonly /></td>
       </tr>
-      <tr id="trselectMilitary"> <!-- DOE029 *add 'selected' to option '00'(No military relation)?-->
+      <tr id="trRace_Military"> <!-- DOE029 -->
         <td class="bold">Family Military Status &tilde;</td>
-        <td>
-          <select id="selectMilitaryStatus" name="[Students.U_Students_Extension]race_militarystatus">
-            <option value="00">Not a member of a military family</option>
-            <option value="01">Yes, child of active duty member</option>
-            <option value="02">Yes, child of member who was medically discharged or retired in the last year</option>
-            <option value="03">Yes, child of member who perished in the line of duty in the last year</option>
-          </select>
-        </td>
+        <td><input type="text" id="fieldMilitaryStatus" value="~([Students.S_MA_STU_X]MilitaryStatus)" size="80" readonly /></td>
       </tr>
     <!--  Custom Fields: 'Office Data' -->
-      <tr class="trfieldEntryDate">
+      <tr id="trOffice_EntryDate">
         <td class="bold">District Entry Date</td>
-        <td>
-          <b class="dpWrapper">
-            <input type="text" id="fieldEntryDate" name="[Students.U_Students_Extension]office_entrydate" value="" size="11" class="psDateWidget hasDatepicker" placeholder="MM/DD/YYYY">
-            <button type="button" class="ui-datepicker-trigger" tabindex="-1"></button>
-          </b>
-        </td>
+        <td><input type="text" id="fieldEntryDate" value="~([Students]DistrictEntryDate)" readonly /></td>
       </tr>
-      <tr id="trselectEntryGrade">
+      <tr id="trOffice_EntryGrade">
         <td class="bold">District Entry Grade &tilde;</td>
-        <td>
-          <select id="selectEntryGrade" name="[Students.U_Students_Extension]office_entrygrade">
-            <option value></option>
-            <option value="-4">-4</option>
-            <option value="-3">-3</option>
-            <option value="PK3">PK3</option>
-            <option value="PK4">PK4</option>
-            <option value="K">K</option>
-            <option value="1">1</option>
-            <option value="2">2</option>
-            <option value="3">3</option>
-            <option value="4">4</option>
-            <option value="5">5</option>
-            <option value="6">6</option>
-            <option value="7">7</option>
-            <option value="8">8</option>
-            <option value="9">9</option>
-            <option value="10">10</option>
-            <option value="11">11</option>
-            <option value="12">12</option>
-            <option value="13">13</option>
-          </select>
-        </td>
+        <td><input type="text" id="fieldEntryGrade" value="~([Students]DistrictEntryGradeLevel)" readonly /></td>
       </tr>
-      <tr id="trfieldSchoolCode">
+      <tr id="trOffice_SchoolCode">
         <td class="bold">School Code &tilde;</td> <!-- DOE015 *code = 0000000[1,2] for SPED (1:gradeLvl >12 or private preschool), (2:homeschooled) -->
-        <td> 
-          <input type="text" id="fieldSchoolCode" name="[Students.U_Students_Extension]office_schoolcode" value="" size="6" placeholder="12345678">
-        </td>
+        <td><input type="text" id="fieldSchoolCode" value="~([Students.S_MA_STU_X]OverrideSchoolCode)" readonly /></td>
       </tr>
-      <tr id="trfieldELCode"> <!-- DOE027 or 24? maybe 41? -->
+      <tr id="trOffice_ELCode"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
-        <td>
-          <input type="text" id="fieldELCode" name="[Students.U_Students_Extension]office_elcode" value="" size="8" placeholder="1234567890">
-        </td>
+        <td><input type="text" id="fieldELCode" value="~([Students.U_Def_Ext_Students]EL)" readonly /></td>
       </tr>
-      <tr class="trfieldFLEPDate">
-        <td class="bold">FLEP Date</td>
-        <td>
-          <b class="dpWrapper">
-            <input type="text" id="fieldFLEPDate" name="[Students.U_Students_Extension]office_flepdate" value="" size="11" class="psDateWidget hasDatepicker" placeholder="MM/DD/YYYY">
-            <button type="button" class="ui-datepicker-trigger" tabindex="-1"></button>
-          </b>
-        </td>
+      <tr id="trOffice_FLEPDate">
+        <td class="bold">FLEP Date &tilde;</td>
+        <td><input type="text" id="fieldFLEPDate" value="~([Students.U_Def_Ext_Students]FLEPDate)" readonly /></td>
       </tr>
-      <tr id="trfieldSPEDCode"> <!-- DOE032, 34, 36, 38, or 40? -->
+      <tr id="trOffice_SPEDCode"> <!-- DOE032, 34, 36, 38, or 40? -->
         <td class="bold">SPED Code &tilde;</td>
-        <td>
-          <input type="text" id="fieldSPEDCode" name="[Students.U_Students_Extension]office_spedcode" value="" size="8" placeholder="1234567890">
-        </td>
+        <td><input type="text" id="fieldSPEDCode" value="~([Students.U_Students_Extension]SPED)" readonly /></td>
       </tr>
-      <tr id="trselect504">
-        <td class="bold">504 Plan &tilde;</td> <!-- DOE039 *add 'selected' to option '00'(Never on plan)?-->
-        <td>
-          <select id="select504" name="[Students.U_Students_Extension]office_504">
-            <option value="00">Has not been on a 504 plan at all this school year</option>
-            <option value="01">Currently on a 504 plan</option>
-            <option value="02">Student is not currently on a 504 plan, but was earlier this school year</option>
-          </select>
-        </td>
+      <tr id="trOffice_504Plan">
+        <td class="bold">504 Plan &tilde;</td> <!-- DOE039-->
+        <td><input type="text" id="field504Plan" value="~([Students.S_MA_STU_SPED_X]Sec504PlanStatus)" size="80" readonly /></td>
       </tr>
     <!--  Custom Fields: 'Graduation Info' -->
-      <tr class="trfieldGradDate">
-        <td class="bold">Graduation Date</td>
-        <td>
-          <b class="dpWrapper">
-            <input type="text" id="fieldGradDate" name="[Students.U_Students_Extension]graduation_graddate" value="" size="11" class="psDateWidget hasDatepicker" placeholder="MM/DD/YYYY">
-            <button type="button" class="ui-datepicker-trigger" tabindex="-1"></button>
-          </b>
-        </td>
+      <tr id="trGrad_Date">
+        <td class="bold">Graduation Date &tilde;</td>
+        <td><input type="text" id="fieldGradDate" value="~([Students.U_StudentsUserFields]Grad_Date)" readonly /></td>
       </tr>
-      <tr id="trfieldCohort">
+      <tr id="trGrad_Cohort">
         <td class="bold">DESE Cohort &tilde;</td>  <!-- Dont know what the cohort options are, could maybe be better as a dropdown? -->
-        <td>
-          <input type="text" id="fieldCohort" name="[Students.U_Students_Extension]graduation_cohort" value="" size="5" placeholder="########"> 
-        </td>
+        <td><input type="text" id="fieldCohort" value="~([Students.U_Def_Ext_Students]cohort)" readonly /></td>
       </tr>
-      <tr id="trselectGradPlan"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
-        <td class="bold">Post-Graduation Plan &tilde;</td>
-        <td>
-          <select id="selectGradPlan" name="[Students.U_Students_Extension]graduation_gradplan">  <!-- DEPENDENCIES: If... -->
-            <option value="500">N/A</option>                                                      <!-- ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate) -->
-            <option value="01">4-Year Public College</option>                                     <!-- ...DOE033 does not = '500', then DOE12 must = '04', '10'(Certificate), or '11'(Completed Grade 12) -->
-            <option value="02">2-Year Public College</option>                                     
-            <option value="03">4-Year Private College</option>
-            <option value="04">2-Year Private College</option>
-            <option value="05">Other Post Secondary (e.g. Trade School)</option>
-            <option value="06">Work</option>
-            <option value="07">Military</option>
-            <option value="08">Other</option>
-            <option value="09">Unknown</option>
-            <option value="10">Registered Apprenticeship</option>
-          </select>
-        </td>
+      <tr id="trGrad_Plan"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
+        <td class="bold">Post-Graduation Plan &tilde;</td> 
+        <td><input type="text" id="fieldGradPlan" value="~([Students.S_MA_STU_X]PostGradPlans)" size="80" readonly /></td>
+         <!-- DEPENDENCIES: If... 
+              ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate)
+              ...DOE033 does not = '500', then DOE12 must = '04', '10'(Certificate), or '11'(Completed Grade 12) -->
       </tr>
-      <tr id="trselectGradCoreCompletion"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
+      <tr id="trGrad_CoreCompletion"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
         <td class="bold">Massachusetts Core Curriculum Completion &tilde;</td>
-        <td>
-          <select id="selectCoreCompleted" name="[Students.U_Students_Extension]graduation_corecompleted">
-            <option value="00">Student is not a graduate</option>
-            <option value="01">Student graduated and successfully completed the Massachusetts Core Curriculum</option>
-            <option value="02">Student graduated without successfully completing the Massachusetts Core Curriculum</option>
-          </select>
-        </td>
+        <td><input type="text" id="fieldCoreCompletion" value="~([Students.S_MA_STU_X]GradCompleteCoreCurriculum)" size="80" readonly /></td>
       </tr>
       <!-- Custom Fields: 'Other' (Built-In) -->
-      <tr id="trselectGradeLvl"> <!-- DOE016 -->
+      <tr id="trOther_NCLB"> <!-- DOE020(?) *DOE020 is for 'Title 1 participation type', this is 'Title 1 School Choice status'. Don't know what the difference is. -->
+        <td class="bold">NCLB/Title 1 School Choice &tilde;</td>
+        <td><input type="text" id="fieldNCLB" value="~([Students.S_MA_STU_SIMS_X]Title1SchoolChoice)" readonly /></td>
+      </tr>
+      <tr id="trOther_GradeLvl"> <!-- DOE016 -->
         <td class="bold">Current Grade Level &tilde;</td>
-        <td>
-          <select id="selectGradeLvl" name="[Students.U_Students_Extension]other_gradelvl">
-            <option value="01">Grade 1</option>
-            <option value="02">Grade 2</option>
-            <option value="03">Grade 3</option>
-            <option value="04">Grade 4</option>
-            <option value="05">Grade 5</option>
-            <option value="06">Grade 6</option>
-            <option value="07">Grade 7</option>
-            <option value="08">Grade 8</option>
-            <option value="09">Grade 9</option>
-            <option value="10">Grade 10</option>
-            <option value="11">Grade 11</option>
-            <option value="12">Grade 12</option>
-            <option value="PK">Pre-K</option>
-            <option value="KP">Kindergarten (Part-time)</option>
-            <option value="KF">Kindergarten (Full-time)</option>
-            <option value="KT">Kindergarten (Tuitioned)</option>
-            <option value="SP">Special Education Beyond Grade 12</option>
-          </select>
-        </td>
+        <td><input type="text" id="fieldGradeLvl" value="~([Students]Grade_Level)" readonly /></td>
       </tr>
     <!-- Custom Fields: 'Other' (LPS)  -->
-      <tr id="trselectFirstYearEL"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
+      <tr id="trOther_FirstYearEL"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
         <td class="bold">First Year English Learner &tilde;</td>
-        <td>
-          <select id="selectFirstYearEL" name="[Students.U_Students_Extension]other_firstyearel">
-            <option value="00">N/A</option>
-            <option value="01">Student in first year of U.S. Schooling</option>
-            <option value="02">Student not in first year of U.S. Schooling</option>
-          </select>
-        </td>
+        <td><input type="text" id="fieldFirstYearEL" value="~([Students.S_MA_STU_Demographic_X]LEP1stYrInUS)" size="80" readonly /></td>
       </tr>
-      <tr id="trcheckboxIsEL"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
+      <tr id="trOther_IsEL"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
         <td class="bold">English Learner &tilde;</td>
-        <td>
-          <input type="checkbox" id="checkboxIsEL" name="[Students.U_Students_Extension]other_isel" value="yes_EL">
-        </td>
+        <td><input type="text" id="fieldIsEL" value="~([Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency)" readonly /></td>
       </tr>
-      <tr id="trselectELStatus"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
+      <tr id="trOther_ELStatus"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
         <td class="bold">EL Program Status &tilde;</td>
-        <td>
-          <select id="selectELStatus" name="[Students.U_Students_Extension]other_elstatus">
-            <option value="00">Not Enrolled in EL Program</option>
-            <option value="01">Sheltered English Immersion</option>
-            <option value="02">Dual Language Education</option>
-            <option value="03">Other Bilingual Program</option>
-            <option value="04">Consented to opt out of all ELE programs offered in the district</option>
-            <option value="05">Transitional Bilingual Education</option>
-          </select>
-        </td>
+        <td><input type="text" id="fieldELStatus" value="~([Students.S_MA_STU_Demographic_X]LEPProgramStatus)" size="80" readonly /></td>
       </tr>
-      <tr id="trfieldSASID"> <!-- DOE002 *10 digits long, -->
+      <tr id="trOther_SASID"> <!-- DOE002 *10 digits long, -->
         <td class="bold">State Assigned Student Identifier (SASID) &tilde;</td>
-        <td>
-          <input type="text" id="fieldSASID" name="[Students.U_Students_Extension]other_sasid" value="" size="8" placeholder="0123456789">
-        </td>
+        <td><input type="text" id="fieldSASID" value="~([Students]State_StudentNumber)" readonly /></td>
       </tr>
-      <tr id="trcheckboxIsImmigrant"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
+      <tr id="trOther_IsImmigrant"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
         <td class="bold">Immigrant &tilde;</td>
-        <td>
-          <input type="checkbox" id="checkboxIsImmigrant" name="[Students.U_Students_Extension]other_isimmigrant" value="yes_immigrant">
-        </td>
+        <td><input type="text" id="fieldImmigrantStatus" value="~([Students.S_MA_STU_Demographic_X]ImmigrantStatus)" readonly /></td>
       </tr>
-      <tr id="trselectEnrollmentStatus"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
+      <tr id="trOther_EnrollmentStatus"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
         <td class="bold">Enrollment Status &tilde;</td>
-        <td>
-          <select id="selectEnrollmentStatus" name="[Students.U_Students_Extension]other_enrollmentstatus">
-            <option value="01">Enrolled</option>
-            <option value="04">Graduate with Competency Determination</option>
-            <option value="05">Expelled</option>
-            <option value="06">Deceased</option>
-            <option value="09">Reached max age, did not graduate or receive a Certificate of attainment</option>
-            <option value="10">Certificate of Attainment</option>
-            <option value="11">11	Completed grade 12 and district-approved program. (District does not offer a Certificate of Attainment)</option>
-            <option value="20">Transferred — In state public</option>
-            <option value="21">Transferred — In state private</option>
-            <option value="22">Transferred — Out-of-State (public or private)</option>
-            <option value="23">Transferred — Home-school</option>
-            <option value="24">Transferred — Adult diploma program, leading to MA diploma</option>
-            <option value="30">Dropout — Enrolled in a non-diploma granting adult education or HiSET program</option>
-            <option value="31">Dropout — Entered Job Corps</option>
-            <option value="32">Dropout — Entered the military</option>
-            <option value="33">Dropout — Incarcerated, district no longer providing educational services</option>
-            <option value="34">Dropout — Left due to employment</option>
-            <option value="35">Dropout — Confirmed Dropout, plans unknown</option>
-            <option value="36">Dropout — and/or student status/location unknown</option>
-            <option value="40">Not enrolled but receiving special education services only.</option>
-            <option value="41">Transferred — no longer receiving special education services only.</option>
-          </select>
-        </td>
-      <tr id="trfieldTransferFrom">
+        <td><input type="text" id="fieldEnrollmentStatus" value="~([Students.S_MA_STU_X]EnrollStatusTimeOfCollection)" size="80" readonly /></td>
+      <tr id="trOther_TransferFrom">
         <td class="bold">Transferring from &tilde;</td>
-        <td>
-          <input type="text" id="fieldTransferFrom" name="[Students.U_Students_Extension]other_transferfrom" value="" size="17" placeholder="School Name">
-        </td>
+        <td><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="School Name" readonly /></td>
       </tr>
-      <tr id="trselectBirthState"> 
+      <tr id="trOther_BirthState"> 
         <td class="bold">Birth State &tilde;</td>
-        <td>
-          <select id="selectBirthState" name="[Students.U_Students_Extension]other_birthstate">
-            <option value=""></option>
-            <option value="AL">Alabama (AL)</option>
-            <option value="AK">Alaska (AK)</option>
-            <option value="AZ">Arizona (AZ)</option>
-            <option value="AR">Arkansas (AR)</option>
-            <option value="CA">California (CA)</option>
-            <option value="CO">Colorado (CO)</option>
-            <option value="CT">Connecticut (CT)</option>
-            <option value="DE">Delaware (DE)</option>
-            <option value="DC">District of Columbia (DC)</option>
-            <option value="FL">Florida (FL)</option>
-            <option value="GA">Georgia (GA)</option>
-            <option value="HI">Hawaii (HI)</option>
-            <option value="ID">Idaho (ID)</option>
-            <option value="IL">Illinois (IL)</option>
-            <option value="IN">Indiana (IN)</option>
-            <option value="IA">Iowa (IA)</option>
-            <option value="KS">Kansas (KS)</option>
-            <option value="KY">Kentucky (KY)</option>
-            <option value="LA">Louisiana (LA)</option>
-            <option value="ME">Maine (ME)</option>
-            <option value="MD">Maryland (MD)</option>
-            <option value="MA" selected>Massachusetts (MA)</option>
-            <option value="MI">Michigan (MI)</option>
-            <option value="MN">Minnesota (MN)</option>
-            <option value="MS">Mississippi (MS)</option>
-            <option value="MO">Missouri (MO)</option>
-            <option value="MT">Montana (MT)</option>
-            <option value="NE">Nebraska (NE)</option>
-            <option value="NV">Nevada (NV)</option>
-            <option value="NH">New Hampshire (NH)</option>
-            <option value="NJ">New Jersey (NJ)</option>
-            <option value="NM">New Mexico (NM)</option>
-            <option value="NY">New York (NY)</option>
-            <option value="NC">North Carolina (NC)</option>
-            <option value="ND">North Dakota (ND)</option>
-            <option value="OH">Ohio (OH)</option>
-            <option value="OK">Oklahoma (OK)</option>
-            <option value="OR">Oregon (OR)</option>
-            <option value="PA">Pennsylvania (PA)</option>
-            <option value="RI">Rhode Island (RI)</option>
-            <option value="SC">South Carolina (SC)</option>
-            <option value="SD">South Dakota (SD)</option>
-            <option value="TN">Tennessee (TN)</option>
-            <option value="TX">Texas (TX)</option>
-            <option value="UT">Utah (UT)</option>
-            <option value="VT">Vermont (VT)</option>
-            <option value="VA">Virginia (VA)</option>
-            <option value="WA">Washington (WA)</option>
-            <option value="WV">West Virginia (WV)</option>
-            <option value="WI">Wisconsin (WI)</option>
-            <option value="WY">Wyoming (WY)</option>
-            <option value="AS">American Samoa (AS)</option>
-            <option value="GU">Guam (GU)</option>
-            <option value="MP">Northern Mariana Islands (MP)</option>
-            <option value="PR">Puerto Rico (PR)</option>
-            <option value="VI">U.S. Virgin Islands (VI)</option>
-          </select>
-        </td>
+        <td><input type="text" id="fieldBirthState" value="~([Students.U_StudentsUserFields]MA_BirthState)" readonly /></td>
       </tr>
-      <tr id="trselectOriginCountry"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
-        <td class="bold">Country of Origin &tilde;</td>
-        <td>
-          <select id="selectOriginCountry" name="[Students.U_Students_Extension]other_origincountry"> <!-- Required if student is immigrant -->
-            <option value=""></option>
-            <option value="500">Not an immigrant student</option>
-          </select>
-        </td>
+      <tr id="trOther_OriginCountry"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
+        <td class="bold">Country of Origin &tilde;</td> <!-- value="500" > not an immigrant student (US Origin) -->
+        <td><input type="text" id="fieldOriginCountry" value="~([Students.S_MA_STU_Demographic_X]CountryOfOrigin)" readonly /></td>
       </tr>
-      <tr id="trselectTeamFlag">
+      <tr id="trOther_TeamFlag">
         <td class="bold">Team Flag &tilde;</td>
-        <td>
-          <select id="selectTeamFlag" name="[Students.U_Students_Extension]other_teamflag">
-            <option value=""></option>
-            <option value="test">*Pretend this is a flag*</option>            
-          </select>
-        </td>  
+        <td><input type="text" id="fieldTeamFlag" value="~([Students.U_StudentsUserFields]TeamFlag)" readonly /></td>
       </tr>
     </tbody>
   </table>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -134,7 +134,7 @@
     <ul>
       <!-- "Show All" option -->
       <li> <!-- This is very broken oh lordy -->
-        <a href="#" id="demoShowAllTab" class="sectTab">
+        <a href="#showAll" id="demoShowAllTab" class="sectTab">
           <input type="checkbox" id="demoShowAllCheckBox" name="demoShowAllCheckBox" value="1" checked>
           <label>Show All (Broken)</label>
         </a>
@@ -173,41 +173,41 @@
             stu.student_number = ~([Students]student_number)]~(email)[/tlist_sql]"
           class="psTextWidget" readonly />
         </td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/emailconfig.html?frn=001113601'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/emailconfig.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
       
       <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Needs to be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trRace_Military" class="row-ethRace ethrace-other"> <!-- DOE029 -->
         <td class="bold">Family Military Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]MilitaryStatus" id="fieldMilitaryStatus" value="~(MilitaryStatus)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#militaryStatus'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#militaryStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!--  Custom Fields: 'Office Data' -->
       <tr id="trOffice_EntryDate" class="row-office office-general">
         <td class="bold">District Entry Date &tilde;</td>
         <td width="75%"><input type="text" name="[Students]DistrictEntryDate" id="fieldEntryDate" value="~(DistrictEntryDate)" placeholder="~[short.date]" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=001113601#dp1626705387672" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=~(frn)#dp1626705387672" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_EntryGrade" class="row-office office-general">
         <td class="bold">District Entry Grade &tilde;</td> <!-- Auto-formatting makes this want a number, so translating it to K/PK might cause issues?   -->
         <td width="75%"><input type="text" name="[Students]DistrictEntryGradeLevel" id="fieldEntryGrade" value="~(DistrictEntryGradeLevel)" class="psTextWidget" readonly /></td>
         <!-- Entry Grade has no ID to link to on target page so linking to Entry Date which is directly above it -->
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=001113601#dp1626705387672" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=~(frn)#dp1626705387672" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_SchoolCode" class="row-office office-general">
         <td class="bold">School Code &tilde;</td> <!-- DOE015 *code = 0000000[1,2] for SPED (1:gradeLvl >12 or private preschool), (2:homeschooled) -->
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]OverrideSchoolCode" id="fieldSchoolCode" value="~(OverrideSchoolCode)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_SchoolCode'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_SchoolCode'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_ELCode" class="row-office office-el"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
         <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]EL" id="fieldELCode" value="~(EL)" placeholder="EL CODE ###..." class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/ellsims.html?frn=001113601'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/ellsims.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_FLEPDate" class="row-office office-el">
         <td class="bold">FLEP Date &tilde;</td> <!-- BUG: For some reason '~[short.date]' returns 'MM/DD/YYYY' here but gives the actual date in #fieldGradDate (I think because gradDate is a custom value) -->
@@ -216,12 +216,12 @@
       <tr id="trOffice_SPEDCode" class="row-office office-sped"> <!-- -->
         <td class="bold">SPED Code &tilde;</td>
         <td width="75%"><input type="text" name="[Students.U_Students_Extension]SPED" id="fieldSPEDCode" value="~(SPED)" placeholder="SPED CODE ###..." class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/spe.html?frn=001113601'" class="editButton" type="button">View</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/spe.html?frn=~(frn)'" class="editButton" type="button">View</button></td>
       </tr>
       <tr id="trOffice_504Plan" class="row-office office-sped">
         <td class="bold">504 Plan &tilde;</td> <!-- DOE039-->
         <td width="75%"><input type="text" name="[Students.S_MA_STU_SPED_X]Sec504PlanStatus" id="field504Plan" value="~(Sec504PlanStatus)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_504PlanStatus'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_504PlanStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!--  Custom Fields: 'Graduation Info' -->
       <tr id="trGrad_Date" class="row-grad">
@@ -235,7 +235,7 @@
       <tr id="trGrad_Plan" class="row-grad"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
         <td class="bold">Post-Graduation Plan &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]PostGradPlans" id="fieldGradPlan" value="~(PostGradPlans)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#futureplans'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#futureplans'" class="editButton" type="button">Edit</button></td>
          <!-- DEPENDENCIES: If...
               ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate)
               ...DOE033 does not = '500', then DOE12 must = '04', '10'(Certificate), or '11'(Completed Grade 12) -->
@@ -243,7 +243,7 @@
       <tr id="trGrad_CoreCompletion" class="row-grad"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
         <td class="bold">Massachusetts Core Curriculum Completion &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]GradCompleteCoreCurriculum" id="fieldCoreCompletion" value="~(GradCompleteCoreCurriculum)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#gradstatus'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#gradstatus'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!-- Custom Fields: 'Legal Info' -->
       <tr id="trLegal_FullName" class="row-legal">
@@ -260,7 +260,7 @@
         <td class="bold">Legal Gender &tilde;</td>
         <td width="75%"><input type="text" name="[Students]Gender" id="fieldLegalGender" value="~(gender)" class="psTextWidget" readonly /></td>
         <!-- Gender on SIMS page doesn't have an ID to link to, should figure out how to get link to focus on it -->
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!-- Custom Fields: 'Other' (LPS)  -->
       <tr id="trOther_NCLB" class="row-other other-lps"> <!-- DOE020(?) *DOE020 is for 'Title 1 participation type', this is 'Title 1 School Choice status'. Don't know what the difference is. -->
@@ -270,32 +270,32 @@
       <tr id="trOther_FirstYearEL" class="row-other other-lps"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
         <td class="bold">First Year English Learner &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEP1stYrInUS" id="fieldFirstYearEL" value="~(LEP1stYrInUS)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_LEPinUS'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_LEPinUS'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_IsEL" class="row-other other-lps"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
         <td class="bold">English Learner &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency" id="fieldIsEL" value="~(LimitedEnglishProficiency)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_EngProficiency'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_EngProficiency'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_ELStatus" class="row-other other-lps"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
         <td class="bold">EL Program Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEPProgramStatus" id="fieldELStatus" value="~(LEPProgramStatus)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#BilingualStatus'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#BilingualStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_SASID" class="row-other other-lps"> <!-- DOE002 *10 digits long, -->
         <td class="bold">State Assigned Student Identifier (SASID) &tilde;</td>
         <td width="75%"><input type="text" name="[Students]State_StudentNumber" id="fieldSASID" value="~(State_StudentNumber)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_IsImmigrant" class="row-other other-lps"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
         <td class="bold">Immigrant &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]ImmigrantStatus" id="fieldImmigrantStatus" value="~(ImmigrantStatus)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_ImmgrStatus'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_ImmgrStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_EnrollmentStatus" class="row-other other-lps"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
         <td class="bold">Enrollment Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]EnrollStatusTimeOfCollection" id="fieldEnrollmentStatus" value="~(EnrollStatusTimeOfCollection)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#enrollstatus'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#enrollstatus'" class="editButton" type="button">Edit</button></td>
       <tr id="trOther_TransferFrom" class="row-other other-lps">
         <td class="bold">Transferring from &tilde;</td>
         <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" class="psTextWidget" readonly /></td>
@@ -307,7 +307,7 @@
       <tr id="trOther_OriginCountry" class="row-other other-lps"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
         <td class="bold">Country of Origin &tilde;</td> <!-- value="500" > not an immigrant student (US Origin) -->
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]CountryOfOrigin" id="fieldOriginCountry" value="~(CountryOfOrigin)" class="psTextWidget" readonly /></td>
-        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_Country'" class="editButton" type="button">Edit</button></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_Country'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_TeamFlag" class="row-other other-lps">
         <td class="bold">Team Flag &tilde;</td>
@@ -319,15 +319,15 @@
 <!-- Grouping these 3 fields in a box-round to communicate that the "Edit" button functions the same for each -->
 <div id="stateIncludeWrapper" class="row-ethRace ethrace-other">
   <div class="button-row" style="margin:0px;padding-bottom:0px;">
-    <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/stateMA.html?frn=001113601'" id="editStateIncludeBtn" type="button">Edit</button>
+    <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/stateMA.html?frn=~(frn)'" id="editStateIncludeBtn" type="button">Edit</button>
   </div>
   <div class="box-round" id="stateIncludeBox">
-    <table class="linkDescList" style="margin-top:0px">
+    <table class="linkDescList" style="margin-top:0px;width:100%;">
       <colgroup>
         <col style="width: auto">
-        <col style="width: 1920px">
+        <col style="width: 100%">
       </colgroup>
-      <tbody width="1920px">
+      <tbody width="100%">
         <tr id="trRace_ExcludeState" class="">
           <td class="bold">Exclude from State Reporting? &tilde;</td>
           <td><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" class="psTextWidget" readonly /></td>
@@ -361,7 +361,7 @@
         <input type="checkbox" id="showAllChkBox" data-ng-disabled="!demoContext.hasEndDateAccess" data-ng-model="context.showAllStudentContacts" 
                data-ng-change="saveShowAllStudentContacts()" />
         <label for="showAllChkBox" data-ng-bind="getShowAllStudentContactsMessageWithCount()"></label>
-        <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/contacts.html?frn=001113601'" id="viewContactsBtn" type="button">View Contacts Page</button>
+        <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/contacts.html?frn=~(frn)'" id="viewContactsBtn" type="button">View Contacts Page</button>
         <!-- ~ "Add" button has been removed for Demographics ~ -->
       </div>
       <p class="feedback-info" data-ng-if="!context.contacts.length" >This student does not have any associated contacts.</p>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -1,34 +1,6 @@
 <!-- use jQuery to replace text -->
 <script src="/admin/javascript/LPSGDC.js"></script>
 <style type="text/css">
-  /* Slide-down navigation bar for section anchors */
-  #demo-navbar {
-    overflow: hidden;
-    background-color: #333;
-    position: fixed;
-    top: -100px;
-    width: 100%;
-    transition: top 0.3s;
-    z-index: 1;
-  }
-  #demo-navbar a {
-    float: left;
-    display: block;
-    color: #f2f2f2;
-    text-align: center;
-    padding: 15px;
-    text-decoration: none;
-    font-size: 17px;
-  }
-  #demo-navbar a:hover {
-    background-color: #ddd;
-    color: black;
-  }
-  #demo-navbar a.active {
-    background-color: #04AA6D;
-    color: white;
-  }
-
   input:read-only {
     border-style: inset;
     border-width: 2px; 
@@ -59,20 +31,29 @@
    -Can either do fields as 'disabled' or 'readonly' 
      *I think the main difference is how it looks but maybe it changes
        submit funcitionality. Setting as 'readonly' for now
+   -In order to save input to database, <input> needs
+     Core Fields:      name="[Table_Name]Field_Name"
+     Extension Fields: name="[PrimaryTable.ExtensionGroupName]Field_Name"
+   -Using ~(Field_Name) applies a default read-only format, ~([Table_Name]Field_Name) does not 
+     
+  BUGS:
+   -Apparently adding name="[Table_Name]Field_Name" to inputs auto-adds
+     certain PS validation attributes/classes and screws up formatting 
+     when you put a field into focus
  -->
 <div id="LPS-GDCustomhiddentable" style="display: none;">
-  <nav id="demo-navbar"> <!-- Add contacts/legal sections when they are done -->
-    <a href="#StudentSection" class="sectLink">Student</a>
-    <a href="#ContactsSection" class="sectLink">Contacts</a>
-    <a href="#EthRaceSection" class="sectLink">Ethnicity & Race</a>
-    <a href="#OfficeSection" class="sectLink">Administration</a>
-    <a href="#GradSection" class="sectLink">Graduation</a>
-    <a href="#LegalSection" class="sectLink">Legal</a>
-    <a href="#OtherSection" class="sectLink">Other</a>
-    <a href="#EverythingElseSection" class="sectLink">Everything Else</a>
-    <a href="javascript:void(0)" id="expandAll">Expand All</a>
-    <a href="javascript:void(0)" id="collapseAll">Collapse All</a>
-  </nav>
+  <div class="tabs" id="demo-navTabs">
+    <ul>
+      <li><a href="#StudentSection" class="sectLink">Student</a></li>
+      <li><a href="#ContactsSection" class="sectLink">Contacts</a></li>
+      <li><a href="#EthRaceSection" class="sectLink">Ethnicity & Race</a></li>
+      <li><a href="#OfficeSection" class="sectLink">Administration</a></li>
+      <li><a href="#GradSection" class="sectLink">Graduation</a></li>
+      <li><a href="#LegalSection" class="sectLink">Legal</a></li>
+      <li><a href="#OtherSection" class="sectLink">Other</a></li>
+      <li><a href="#EverythingElseSection" class="sectLink">Everything Else</a></li>
+    </ul>
+  </div>
   <table>
     <tbody>
     <!--  Custom Fields: 'Student Info' -->
@@ -105,131 +86,131 @@
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
       <tr id="trRace_ExcludeState" class="row-ethRace ethrace-other">
         <td class="bold">Exclude from State Reporting? &tilde;</td>
-        <td width="75%"><input type="text" id="fieldExcludeState" value="~([Students]State_ExcludeFromReporting)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" readonly /></td>
       </tr>
       <tr id="trRace_IncludeSIMS" class="row-ethRace ethrace-other">
         <td class="bold">Include in SIMS Report? &tilde;</td>
-        <td width="75%"><input type="text" id="fieldIncludeSIMS" value="~([Students.S_MA_STU_SIMS_X]IncludeInSIMSInd)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)" readonly /></td>
       </tr>
       <tr id="trRace_IncludeSASID" class="row-ethRace ethrace-other">
         <td class="bold">Include in SASID Report? &tilde;</td>
-        <td width="75%"><input type="text" id="fieldIncludeSASID" value="~([Students.S_MA_STU_X]IncludeInSASIDMSRInd)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)" readonly /></td>
       </tr>
       <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Needs to be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
-        <td width="75%"><input type="text" id="fieldBirthCity" value="~([Students.S_MA_STU_Demographic_X]BirthCity)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)" readonly /></td>
       </tr>
       <tr id="trRace_Military" class="row-ethRace ethrace-other"> <!-- DOE029 -->
         <td class="bold">Family Military Status &tilde;</td>
-        <td width="75%"><input type="text" id="fieldMilitaryStatus" value="~([Students.S_MA_STU_X]MilitaryStatus)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]MilitaryStatus" id="fieldMilitaryStatus" value="~(MilitaryStatus)" readonly /></td>
       </tr>
     <!--  Custom Fields: 'Office Data' -->
       <tr id="trOffice_EntryDate" class="row-office office-general">
         <td class="bold">District Entry Date &tilde;</td>
-        <td width="75%"><input type="text" id="fieldEntryDate" value="~([Students]DistrictEntryDate)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students]DistrictEntryDate" id="fieldEntryDate" value="~(DistrictEntryDate)" placeholder="~[short.date]" readonly /></td>
       </tr>
       <tr id="trOffice_EntryGrade" class="row-office office-general">
-        <td class="bold">District Entry Grade &tilde;</td> <!-- might change to text input, don't know if uses '-2' or 'PK' for pre-school value   -->
-        <td width="75%"><input type="number" id="fieldEntryGrade" value="~([Students]DistrictEntryGradeLevel)" min="-2" max="13" readonly /></td>
+        <td class="bold">District Entry Grade &tilde;</td> <!-- Auto-formatting makes this want a number, so translating it to K/PK might cause issues?   -->
+        <td width="75%"><input type="text" name="[Students]DistrictEntryGradeLevel" id="fieldEntryGrade" value="~(DistrictEntryGradeLevel)" readonly /></td>
       </tr>
       <tr id="trOffice_SchoolCode" class="row-office office-general">
         <td class="bold">School Code &tilde;</td> <!-- DOE015 *code = 0000000[1,2] for SPED (1:gradeLvl >12 or private preschool), (2:homeschooled) -->
-        <td width="75%"><input type="text" id="fieldSchoolCode" value="~([Students.S_MA_STU_X]OverrideSchoolCode)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]OverrideSchoolCode" id="fieldSchoolCode" value="~(OverrideSchoolCode)" readonly /></td>
       </tr>
       <tr id="trOffice_ELCode" class="row-office office-el"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
-        <td width="75%"><input type="text" id="fieldELCode" value="~([Students.U_Def_Ext_Students]EL)" placeholder="EL CODE ###..." readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]EL" id="fieldELCode" value="~(EL)" placeholder="EL CODE ###..." readonly /></td>
       </tr>
-      <tr id="trOffice_FLEPDate" class="row-office office-el">
+      <tr id="trOffice_FLEPDate" class="row-office office-el"> <!-- BUG: For some reason '~[short.date]' returns 'MM/DD/YYYY' here but gives the actual date in #fieldGradDate (I think because gradDate is a custom value) -->
         <td class="bold">FLEP Date &tilde;</td>
-        <td width="75%"><input type="text" id="fieldFLEPDate" value="~([Students.U_Def_Ext_Students]FLEPDate)" placeholder="01/01/1999" readonly /></td><!-- placeholder doesnt seem to work for dates -->
+        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]FLEPDate" id="fieldFLEPDate" value="~(FLEPDate)" placeholder="~[short.date]" readonly /></td>
       </tr>
-      <tr id="trOffice_SPEDCode" class="row-office office-sped"> <!-- DOE032, 34, 36, 38, or 40? -->
+      <tr id="trOffice_SPEDCode" class="row-office office-sped"> <!-- -->
         <td class="bold">SPED Code &tilde;</td>
-        <td width="75%"><input type="text" id="fieldSPEDCode" value="~([Students.U_Students_Extension]SPED)" placeholder="SPED CODE ###..." readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Students_Extension]SPED" id="fieldSPEDCode" value="~(SPED)" placeholder="SPED CODE ###..." readonly /></td>
       </tr>
       <tr id="trOffice_504Plan" class="row-office office-sped">
         <td class="bold">504 Plan &tilde;</td> <!-- DOE039-->
-        <td width="75%"><input type="text" id="field504Plan" value="~([Students.S_MA_STU_SPED_X]Sec504PlanStatus)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_SPED_X]Sec504PlanStatus" id="field504Plan" value="~(Sec504PlanStatus)" readonly /></td>
       </tr>
     <!--  Custom Fields: 'Graduation Info' -->
       <tr id="trGrad_Date" class="row-grad">
         <td class="bold">Graduation Date &tilde;</td>
-        <td width="75%"><input type="text" id="fieldGradDate" value="~([Students.U_StudentsUserFields]Grad_Date)" placeholder="01/01/1999" readonly /></td><!-- placeholder doesnt seem to work for dates -->
+        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]Grad_Date" id="fieldGradDate" value="~(Grad_Date)" placeholder="~[short.date]" readonly /></td>
       </tr>
       <tr id="trGrad_Cohort" class="row-grad">
-        <td class="bold">DESE Cohort &tilde;</td>  <!-- Dont know what the cohort options are, could maybe be better as a dropdown? -->
-        <td width="75%"><input type="text" id="fieldCohort" value="~([Students.U_Def_Ext_Students]cohort)" placeholder="COHORT #..." readonly /></td>
+        <td class="bold">DESE Cohort &tilde;</td>
+        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]cohort" id="fieldCohort" value="~(cohort)" placeholder="COHORT #..." readonly /></td>
       </tr>
       <tr id="trGrad_Plan" class="row-grad"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
         <td class="bold">Post-Graduation Plan &tilde;</td> 
-        <td width="75%"><input type="text" id="fieldGradPlan" value="~([Students.S_MA_STU_X]PostGradPlans)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]PostGradPlans" id="fieldGradPlan" value="~(PostGradPlans)" readonly /></td>
          <!-- DEPENDENCIES: If... 
               ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate)
               ...DOE033 does not = '500', then DOE12 must = '04', '10'(Certificate), or '11'(Completed Grade 12) -->
       </tr>
       <tr id="trGrad_CoreCompletion" class="row-grad"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
         <td class="bold">Massachusetts Core Curriculum Completion &tilde;</td>
-        <td width="75%"><input type="text" id="fieldCoreCompletion" value="~([Students.S_MA_STU_X]GradCompleteCoreCurriculum)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]GradCompleteCoreCurriculum" id="fieldCoreCompletion" value="~(GradCompleteCoreCurriculum)" readonly /></td>
       </tr>
     <!-- Custom Fields: 'Legal Info' -->
       <tr id="trLegal_FullName" class="row-legal">
         <td class="bold">Legal Name (Last, First Middle Suffix) &tilde;</td>
         <td width="75%">
-          <input type="text" id="fieldLegalLast_temp" value="~([Students.StudentCoreFields]PSCore_Legal_Last_Name)" style="width:35%" placeholder="SMITH..." readonly /> ,
-          <input type="text" id="fieldLegalFirst_temp" value="~([Students.StudentCoreFields]PSCore_Legal_First_Name)" style="width:35%" placeholder="JOHN..." readonly />
-          <input type="text" id="fieldLegalMiddle_temp" value="~([Students.StudentCoreFields]PSCore_Legal_Middle_Name)" style="width:15%" placeholder="WILLIAM..." readonly />
-          <input type="text" id="fieldLegalSuffix_temp" value="~([Students.StudentCoreFields]PSCore_Legal_Suffix)" style="width:15%" placeholder="Sr., Jr., III, etc..." readonly />
+          <input type="text" id="fieldLegalLast_temp" name="[Students.StudentCoreFields]PSCore_Legal_Last_Name" value="~(PSCore_Legal_Last_Name)" style="width:35%" placeholder="SMITH..." readonly /> ,
+          <input type="text" id="fieldLegalFirst_temp" name="[Students.StudentCoreFields]PSCore_Legal_First_Name" value="~(PSCore_Legal_First_Name)" style="width:35%" placeholder="JOHN..." readonly />
+          <input type="text" id="fieldLegalMiddle_temp" name="[Students.StudentCoreFields]PSCore_Legal_Middle_Name" value="~(PSCore_Legal_Middle_Name)" style="width:15%" placeholder="WILLIAM..." readonly />
+          <input type="text" id="fieldLegalSuffix_temp" name="[Students.StudentCoreFields]PSCore_Legal_Suffix" value="~(PSCore_Legal_Suffix)" style="width:15%" placeholder="Sr., Jr., III, etc..." readonly />
           <button type="button" onclick="StudentCoreLegalModule.copyToLegalNameFields('lastName', 'firstName', 'middleName', 'fieldLegalLast_temp', 'fieldLegalFirst_temp', 'fieldLegalMiddle_temp', 'fieldLegalSuffix_temp');">Copy</button>
         </td>
       </tr>
       <tr id="trLegal_Gender" class="row-legal">
         <td class="bold">Legal Gender &tilde;</td>
-        <td width="75%"><input type="text" id="fieldLegalGender" value="~([Students]Gender)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students]Gender" id="fieldLegalGender" value="~(gender)" readonly /></td>
       </tr>
     <!-- Custom Fields: 'Other' (LPS)  -->
       <tr id="trOther_NCLB" class="row-other other-lps"> <!-- DOE020(?) *DOE020 is for 'Title 1 participation type', this is 'Title 1 School Choice status'. Don't know what the difference is. -->
         <td class="bold">NCLB/Title 1 School Choice &tilde;</td>
-        <td width="75%"><input type="text" id="fieldNCLB" value="~([Students.S_MA_STU_SIMS_X]Title1SchoolChoice)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_SIMS_X]Title1SchoolChoice" id="fieldNCLB" value="~(Title1SchoolChoice)" readonly /></td>
       </tr>
       <tr id="trOther_FirstYearEL" class="row-other other-lps"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
         <td class="bold">First Year English Learner &tilde;</td>
-        <td width="75%"><input type="text" id="fieldFirstYearEL" value="~([Students.S_MA_STU_Demographic_X]LEP1stYrInUS)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEP1stYrInUS" id="fieldFirstYearEL" value="~(LEP1stYrInUS)" readonly /></td>
       </tr>
       <tr id="trOther_IsEL" class="row-other other-lps"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
         <td class="bold">English Learner &tilde;</td>
-        <td width="75%"><input type="text" id="fieldIsEL" value="~([Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency" id="fieldIsEL" value="~(LimitedEnglishProficiency)" readonly /></td>
       </tr>
       <tr id="trOther_ELStatus" class="row-other other-lps"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
         <td class="bold">EL Program Status &tilde;</td>
-        <td width="75%"><input type="text" id="fieldELStatus" value="~([Students.S_MA_STU_Demographic_X]LEPProgramStatus)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEPProgramStatus" id="fieldELStatus" value="~(LEPProgramStatus)" readonly /></td>
       </tr>
       <tr id="trOther_SASID" class="row-other other-lps"> <!-- DOE002 *10 digits long, -->
         <td class="bold">State Assigned Student Identifier (SASID) &tilde;</td>
-        <td width="75%"><input type="text" id="fieldSASID" value="~([Students]State_StudentNumber)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students]State_StudentNumber" id="fieldSASID" value="~(State_StudentNumber)" readonly /></td>
       </tr>
       <tr id="trOther_IsImmigrant" class="row-other other-lps"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
         <td class="bold">Immigrant &tilde;</td>
-        <td width="75%"><input type="text" id="fieldImmigrantStatus" value="~([Students.S_MA_STU_Demographic_X]ImmigrantStatus)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]ImmigrantStatus" id="fieldImmigrantStatus" value="~(ImmigrantStatus)" readonly /></td>
       </tr>
       <tr id="trOther_EnrollmentStatus" class="row-other other-lps"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
         <td class="bold">Enrollment Status &tilde;</td>
-        <td width="75%"><input type="text" id="fieldEnrollmentStatus" value="~([Students.S_MA_STU_X]EnrollStatusTimeOfCollection)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]EnrollStatusTimeOfCollection" id="fieldEnrollmentStatus" value="~(EnrollStatusTimeOfCollection)" readonly /></td>
       <tr id="trOther_TransferFrom" class="row-other other-lps">
         <td class="bold">Transferring from &tilde;</td>
         <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" readonly /></td>
       </tr>
       <tr id="trOther_BirthState" class="row-other other-lps"> 
         <td class="bold">Birth State &tilde;</td>
-        <td width="75%"><input type="text" id="fieldBirthState" value="~([Students.U_StudentsUserFields]MA_BirthState)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]MA_BirthState" id="fieldBirthState" value="~(MA_BirthState)" readonly /></td>
       </tr>
       <tr id="trOther_OriginCountry" class="row-other other-lps"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
         <td class="bold">Country of Origin &tilde;</td> <!-- value="500" > not an immigrant student (US Origin) -->
-        <td width="75%"><input type="text" id="fieldOriginCountry" value="~([Students.S_MA_STU_Demographic_X]CountryOfOrigin)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]CountryOfOrigin" id="fieldOriginCountry" value="~(CountryOfOrigin)" readonly /></td>
       </tr>
       <tr id="trOther_TeamFlag" class="row-other other-lps">
         <td class="bold">Team Flag &tilde;</td>
-        <td width="75%"><input type="text" id="fieldTeamFlag" value="~([Students.U_StudentsUserFields]TeamFlag)"  placeholder="TEAM FLAG..." readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]TeamFlag" id="fieldTeamFlag" value="~(TeamFlag)"  placeholder="TEAM FLAG..." readonly /></td>
       </tr>
     </tbody>
   </table>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -64,9 +64,11 @@
     border-width: 2px;
     border-color: rgb(118,118,118) rgb(133,133,133) rgb(133,133,133) rgb(118,118,118);
     padding: 3px;
-    background-color: rgb(217,217,217); /* highlight custom fields grey */
+    background-color: rgb(255,255,255);
+    /*background-color: rgb(217,217,217);*/ /* highlight custom fields grey !!FOR BUG-FINDING/FIXING ONLY!! */
   }
-  /* highlight fields: incomplete = red, completed = green */
+  /* highlight fields: incomplete = red, completed = green !!FOR BUG-FINDING/FIXING ONLY!! */
+  /*
   input:invalid {
     background-color: rgb(230, 179, 179);
   }
@@ -79,6 +81,7 @@
   input.noValue {
     background-color: rgb(230, 179, 179);
   }
+  */
   input:only-child {
     width: 99%;
   }
@@ -151,11 +154,11 @@
     <!--  Custom Fields: 'Student Info' -->
       <tr id="trStudent_Mobile" class="row-student student-contactInfo">
         <td class="bold">Student Mobile &tilde;</td><!-- where is this info stored? -->
-        <td width="75%"><input type="tel" id="fieldStudentMobile" value="" placeholder="123-456-7890" readonly /></td>
+        <td width="75%"><input type="tel" id="fieldStudentMobile" value="" placeholder="123-456-7890" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trStudent_PersonalEmail" class="row-student student-contactInfo">
         <td class="bold">Student Personal Email &tilde;</td>
-        <td width="75%"><input type="email" id="fieldPersonalEmail" value="" placeholder="student@example.com" readonly /></td>
+        <td width="75%"><input type="email" id="fieldPersonalEmail" value="" placeholder="student@example.com" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trStudent_LPSEmail" class="row-student student-contactInfo">
         <td class="bold">Student LPS Email &tilde;</td>
@@ -168,7 +171,7 @@
             JOIN Students stu ON ssm.studentsdcid = stu.dcid
           WHERE
             stu.student_number = ~([Students]student_number)]~(email)[/tlist_sql]"
-          readonly />
+          class="psTextWidget" readonly />
         </td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/emailconfig.html?frn=001113601'" class="editButton" type="button">Edit</button></td>
       </tr>
@@ -176,62 +179,62 @@
       
       <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Needs to be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trRace_Military" class="row-ethRace ethrace-other"> <!-- DOE029 -->
         <td class="bold">Family Military Status &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]MilitaryStatus" id="fieldMilitaryStatus" value="~(MilitaryStatus)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]MilitaryStatus" id="fieldMilitaryStatus" value="~(MilitaryStatus)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#militaryStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!--  Custom Fields: 'Office Data' -->
       <tr id="trOffice_EntryDate" class="row-office office-general">
         <td class="bold">District Entry Date &tilde;</td>
-        <td width="75%"><input type="text" name="[Students]DistrictEntryDate" id="fieldEntryDate" value="~(DistrictEntryDate)" placeholder="~[short.date]" readonly /></td>
+        <td width="75%"><input type="text" name="[Students]DistrictEntryDate" id="fieldEntryDate" value="~(DistrictEntryDate)" placeholder="~[short.date]" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=001113601#dp1626705387672" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_EntryGrade" class="row-office office-general">
         <td class="bold">District Entry Grade &tilde;</td> <!-- Auto-formatting makes this want a number, so translating it to K/PK might cause issues?   -->
-        <td width="75%"><input type="text" name="[Students]DistrictEntryGradeLevel" id="fieldEntryGrade" value="~(DistrictEntryGradeLevel)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students]DistrictEntryGradeLevel" id="fieldEntryGrade" value="~(DistrictEntryGradeLevel)" class="psTextWidget" readonly /></td>
         <!-- Entry Grade has no ID to link to on target page so linking to Entry Date which is directly above it -->
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=001113601#dp1626705387672" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_SchoolCode" class="row-office office-general">
         <td class="bold">School Code &tilde;</td> <!-- DOE015 *code = 0000000[1,2] for SPED (1:gradeLvl >12 or private preschool), (2:homeschooled) -->
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]OverrideSchoolCode" id="fieldSchoolCode" value="~(OverrideSchoolCode)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]OverrideSchoolCode" id="fieldSchoolCode" value="~(OverrideSchoolCode)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_SchoolCode'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_ELCode" class="row-office office-el"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]EL" id="fieldELCode" value="~(EL)" placeholder="EL CODE ###..." readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]EL" id="fieldELCode" value="~(EL)" placeholder="EL CODE ###..." class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/ellsims.html?frn=001113601'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_FLEPDate" class="row-office office-el">
         <td class="bold">FLEP Date &tilde;</td> <!-- BUG: For some reason '~[short.date]' returns 'MM/DD/YYYY' here but gives the actual date in #fieldGradDate (I think because gradDate is a custom value) -->
-        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]FLEPDate" id="fieldFLEPDate" value="~(FLEPDate)" placeholder="~[short.date]" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]FLEPDate" id="fieldFLEPDate" value="~(FLEPDate)" placeholder="~[short.date]" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trOffice_SPEDCode" class="row-office office-sped"> <!-- -->
         <td class="bold">SPED Code &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_Students_Extension]SPED" id="fieldSPEDCode" value="~(SPED)" placeholder="SPED CODE ###..." readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Students_Extension]SPED" id="fieldSPEDCode" value="~(SPED)" placeholder="SPED CODE ###..." class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/spe.html?frn=001113601'" class="editButton" type="button">View</button></td>
       </tr>
       <tr id="trOffice_504Plan" class="row-office office-sped">
         <td class="bold">504 Plan &tilde;</td> <!-- DOE039-->
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_SPED_X]Sec504PlanStatus" id="field504Plan" value="~(Sec504PlanStatus)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_SPED_X]Sec504PlanStatus" id="field504Plan" value="~(Sec504PlanStatus)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_504PlanStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!--  Custom Fields: 'Graduation Info' -->
       <tr id="trGrad_Date" class="row-grad">
         <td class="bold">Graduation Date &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]Grad_Date" id="fieldGradDate" value="~(Grad_Date)" placeholder="~[short.date]" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]Grad_Date" id="fieldGradDate" value="~(Grad_Date)" placeholder="~[short.date]" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trGrad_Cohort" class="row-grad">
         <td class="bold">DESE Cohort &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]cohort" id="fieldCohort" value="~(cohort)" placeholder="COHORT #..." readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]cohort" id="fieldCohort" value="~(cohort)" placeholder="COHORT #..." class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trGrad_Plan" class="row-grad"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
         <td class="bold">Post-Graduation Plan &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]PostGradPlans" id="fieldGradPlan" value="~(PostGradPlans)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]PostGradPlans" id="fieldGradPlan" value="~(PostGradPlans)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#futureplans'" class="editButton" type="button">Edit</button></td>
          <!-- DEPENDENCIES: If...
               ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate)
@@ -239,76 +242,76 @@
       </tr>
       <tr id="trGrad_CoreCompletion" class="row-grad"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
         <td class="bold">Massachusetts Core Curriculum Completion &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]GradCompleteCoreCurriculum" id="fieldCoreCompletion" value="~(GradCompleteCoreCurriculum)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]GradCompleteCoreCurriculum" id="fieldCoreCompletion" value="~(GradCompleteCoreCurriculum)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#gradstatus'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!-- Custom Fields: 'Legal Info' -->
       <tr id="trLegal_FullName" class="row-legal">
         <td class="bold">Legal Name (Last, First Middle Suffix) &tilde;</td>
         <td width="75%">
-          <input type="text" id="fieldLegalLast_temp" name="[Students.StudentCoreFields]PSCore_Legal_Last_Name" value="~(PSCore_Legal_Last_Name)" style="width:35%" placeholder="SMITH..." readonly /> ,
-          <input type="text" id="fieldLegalFirst_temp" name="[Students.StudentCoreFields]PSCore_Legal_First_Name" value="~(PSCore_Legal_First_Name)" style="width:35%" placeholder="JOHN..." readonly />
-          <input type="text" id="fieldLegalMiddle_temp" name="[Students.StudentCoreFields]PSCore_Legal_Middle_Name" value="~(PSCore_Legal_Middle_Name)" style="width:15%" placeholder="WILLIAM..." readonly />
-          <input type="text" id="fieldLegalSuffix_temp" name="[Students.StudentCoreFields]PSCore_Legal_Suffix" value="~(PSCore_Legal_Suffix)" style="width:15%" placeholder="Sr., Jr., III, etc..." readonly />
+          <input type="text" id="fieldLegalLast_temp" name="[Students.StudentCoreFields]PSCore_Legal_Last_Name" value="~(PSCore_Legal_Last_Name)" style="width:35%" placeholder="SMITH..." class="psTextWidget" readonly /> ,
+          <input type="text" id="fieldLegalFirst_temp" name="[Students.StudentCoreFields]PSCore_Legal_First_Name" value="~(PSCore_Legal_First_Name)" style="width:35%" placeholder="JOHN..." class="psTextWidget" readonly />
+          <input type="text" id="fieldLegalMiddle_temp" name="[Students.StudentCoreFields]PSCore_Legal_Middle_Name" value="~(PSCore_Legal_Middle_Name)" style="width:15%" placeholder="WILLIAM..." class="psTextWidget" readonly />
+          <input type="text" id="fieldLegalSuffix_temp" name="[Students.StudentCoreFields]PSCore_Legal_Suffix" value="~(PSCore_Legal_Suffix)" style="width:15%" placeholder="Sr., Jr., III, etc..." class="psTextWidget" readonly />
           <button type="button" onclick="StudentCoreLegalModule.copyToLegalNameFields('lastName', 'firstName', 'middleName', 'fieldLegalLast_temp', 'fieldLegalFirst_temp', 'fieldLegalMiddle_temp', 'fieldLegalSuffix_temp');">Copy</button>
         </td>
       </tr>
       <tr id="trLegal_Gender" class="row-legal">
         <td class="bold">Legal Gender &tilde;</td>
-        <td width="75%"><input type="text" name="[Students]Gender" id="fieldLegalGender" value="~(gender)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students]Gender" id="fieldLegalGender" value="~(gender)" class="psTextWidget" readonly /></td>
         <!-- Gender on SIMS page doesn't have an ID to link to, should figure out how to get link to focus on it -->
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!-- Custom Fields: 'Other' (LPS)  -->
       <tr id="trOther_NCLB" class="row-other other-lps"> <!-- DOE020(?) *DOE020 is for 'Title 1 participation type', this is 'Title 1 School Choice status'. Don't know what the difference is. -->
         <td class="bold">NCLB/Title 1 School Choice &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_SIMS_X]Title1SchoolChoice" id="fieldNCLB" value="~(Title1SchoolChoice)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_SIMS_X]Title1SchoolChoice" id="fieldNCLB" value="~(Title1SchoolChoice)" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trOther_FirstYearEL" class="row-other other-lps"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
         <td class="bold">First Year English Learner &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEP1stYrInUS" id="fieldFirstYearEL" value="~(LEP1stYrInUS)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEP1stYrInUS" id="fieldFirstYearEL" value="~(LEP1stYrInUS)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_LEPinUS'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_IsEL" class="row-other other-lps"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
         <td class="bold">English Learner &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency" id="fieldIsEL" value="~(LimitedEnglishProficiency)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency" id="fieldIsEL" value="~(LimitedEnglishProficiency)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_EngProficiency'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_ELStatus" class="row-other other-lps"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
         <td class="bold">EL Program Status &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEPProgramStatus" id="fieldELStatus" value="~(LEPProgramStatus)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEPProgramStatus" id="fieldELStatus" value="~(LEPProgramStatus)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#BilingualStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_SASID" class="row-other other-lps"> <!-- DOE002 *10 digits long, -->
         <td class="bold">State Assigned Student Identifier (SASID) &tilde;</td>
-        <td width="75%"><input type="text" name="[Students]State_StudentNumber" id="fieldSASID" value="~(State_StudentNumber)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students]State_StudentNumber" id="fieldSASID" value="~(State_StudentNumber)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_IsImmigrant" class="row-other other-lps"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
         <td class="bold">Immigrant &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]ImmigrantStatus" id="fieldImmigrantStatus" value="~(ImmigrantStatus)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]ImmigrantStatus" id="fieldImmigrantStatus" value="~(ImmigrantStatus)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_ImmgrStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_EnrollmentStatus" class="row-other other-lps"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
         <td class="bold">Enrollment Status &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]EnrollStatusTimeOfCollection" id="fieldEnrollmentStatus" value="~(EnrollStatusTimeOfCollection)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]EnrollStatusTimeOfCollection" id="fieldEnrollmentStatus" value="~(EnrollStatusTimeOfCollection)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#enrollstatus'" class="editButton" type="button">Edit</button></td>
       <tr id="trOther_TransferFrom" class="row-other other-lps">
         <td class="bold">Transferring from &tilde;</td>
-        <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" readonly /></td>
+        <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trOther_BirthState" class="row-other other-lps">
         <td class="bold">Birth State &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]MA_BirthState" id="fieldBirthState" value="~(MA_BirthState)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]MA_BirthState" id="fieldBirthState" value="~(MA_BirthState)" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trOther_OriginCountry" class="row-other other-lps"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
         <td class="bold">Country of Origin &tilde;</td> <!-- value="500" > not an immigrant student (US Origin) -->
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]CountryOfOrigin" id="fieldOriginCountry" value="~(CountryOfOrigin)" readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]CountryOfOrigin" id="fieldOriginCountry" value="~(CountryOfOrigin)" class="psTextWidget" readonly /></td>
         <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_Country'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_TeamFlag" class="row-other other-lps">
         <td class="bold">Team Flag &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]TeamFlag" id="fieldTeamFlag" value="~(TeamFlag)"  placeholder="TEAM FLAG..." readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]TeamFlag" id="fieldTeamFlag" value="~(TeamFlag)"  placeholder="TEAM FLAG..." class="psTextWidget" readonly /></td>
       </tr>
     </tbody>
   </table>
@@ -327,15 +330,15 @@
       <tbody width="1920px">
         <tr id="trRace_ExcludeState" class="">
           <td class="bold">Exclude from State Reporting? &tilde;</td>
-          <td><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" readonly /></td>
+          <td><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" class="psTextWidget" readonly /></td>
         </tr> <!-- All "include/exclude" fields are in the same place so only need one edit button link -->
         <tr id="trRace_IncludeSIMS" class="">
           <td class="bold">Include in SIMS Report? &tilde;</td>
-          <td><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)" readonly /></td>
+          <td><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)" class="psTextWidget" readonly /></td>
         </tr>
         <tr id="trRace_IncludeSASID" class="">
           <td class="bold">Include in SASID Report? &tilde;</td>
-          <td><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)" readonly /></td>
+          <td><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)" class="psTextWidget" readonly /></td>
         </tr>
       </tbody>
     </table>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -83,6 +83,20 @@
     width: 99%;
   }
   
+  .editButton {
+    float: right;
+  }
+  
+  #editStateIncludeBtn {
+    margin-top: 0px;
+  }
+  
+  #stateIncludeBox {
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-bottom: 0px;
+  }
+  
   #demoContactsSection {
     border-style: none;
   }
@@ -98,6 +112,7 @@
   - Using ~(Field_Name) applies default read-only format, ~([Table_Name]Field_Name) does not
   - Apparently adding name="[Table_Name]Field_Name" to inputs auto-adds certain PS
      validation attributes/classes and screws up formatting when you put a field into focus
+  - Im going to want to change the edit links to not specificially link to frn=001113601
  -->
 <div id="LPS-GDCustomhiddentable" style="display: none;">
   <nav id="demo-navbar">
@@ -155,56 +170,55 @@
             stu.student_number = ~([Students]student_number)]~(email)[/tlist_sql]"
           readonly />
         </td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/emailconfig.html?frn=001113601'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
-      <tr id="trRace_ExcludeState" class="row-ethRace ethrace-other">
-        <td class="bold">Exclude from State Reporting? &tilde;</td>
-        <td width="75%"><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" readonly /></td>
-      </tr>
-      <tr id="trRace_IncludeSIMS" class="row-ethRace ethrace-other">
-        <td class="bold">Include in SIMS Report? &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)" readonly /></td>
-      </tr>
-      <tr id="trRace_IncludeSASID" class="row-ethRace ethrace-other">
-        <td class="bold">Include in SASID Report? &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)" readonly /></td>
-      </tr>
+      
       <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Needs to be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trRace_Military" class="row-ethRace ethrace-other"> <!-- DOE029 -->
         <td class="bold">Family Military Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]MilitaryStatus" id="fieldMilitaryStatus" value="~(MilitaryStatus)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#militaryStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!--  Custom Fields: 'Office Data' -->
       <tr id="trOffice_EntryDate" class="row-office office-general">
         <td class="bold">District Entry Date &tilde;</td>
         <td width="75%"><input type="text" name="[Students]DistrictEntryDate" id="fieldEntryDate" value="~(DistrictEntryDate)" placeholder="~[short.date]" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=001113601#dp1626705387672" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_EntryGrade" class="row-office office-general">
         <td class="bold">District Entry Grade &tilde;</td> <!-- Auto-formatting makes this want a number, so translating it to K/PK might cause issues?   -->
         <td width="75%"><input type="text" name="[Students]DistrictEntryGradeLevel" id="fieldEntryGrade" value="~(DistrictEntryGradeLevel)" readonly /></td>
+        <!-- Entry Grade has no ID to link to on target page so linking to Entry Date which is directly above it -->
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/modifydata.html?frn=001113601#dp1626705387672" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_SchoolCode" class="row-office office-general">
         <td class="bold">School Code &tilde;</td> <!-- DOE015 *code = 0000000[1,2] for SPED (1:gradeLvl >12 or private preschool), (2:homeschooled) -->
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]OverrideSchoolCode" id="fieldSchoolCode" value="~(OverrideSchoolCode)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_SchoolCode'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOffice_ELCode" class="row-office office-el"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
         <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]EL" id="fieldELCode" value="~(EL)" placeholder="EL CODE ###..." readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/ellsims.html?frn=001113601'" class="editButton" type="button">Edit</button></td>
       </tr>
-      <tr id="trOffice_FLEPDate" class="row-office office-el"> <!-- BUG: For some reason '~[short.date]' returns 'MM/DD/YYYY' here but gives the actual date in #fieldGradDate (I think because gradDate is a custom value) -->
-        <td class="bold">FLEP Date &tilde;</td>
+      <tr id="trOffice_FLEPDate" class="row-office office-el">
+        <td class="bold">FLEP Date &tilde;</td> <!-- BUG: For some reason '~[short.date]' returns 'MM/DD/YYYY' here but gives the actual date in #fieldGradDate (I think because gradDate is a custom value) -->
         <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]FLEPDate" id="fieldFLEPDate" value="~(FLEPDate)" placeholder="~[short.date]" readonly /></td>
       </tr>
       <tr id="trOffice_SPEDCode" class="row-office office-sped"> <!-- -->
         <td class="bold">SPED Code &tilde;</td>
         <td width="75%"><input type="text" name="[Students.U_Students_Extension]SPED" id="fieldSPEDCode" value="~(SPED)" placeholder="SPED CODE ###..." readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/spe.html?frn=001113601'" class="editButton" type="button">View</button></td>
       </tr>
       <tr id="trOffice_504Plan" class="row-office office-sped">
         <td class="bold">504 Plan &tilde;</td> <!-- DOE039-->
         <td width="75%"><input type="text" name="[Students.S_MA_STU_SPED_X]Sec504PlanStatus" id="field504Plan" value="~(Sec504PlanStatus)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_504PlanStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!--  Custom Fields: 'Graduation Info' -->
       <tr id="trGrad_Date" class="row-grad">
@@ -218,6 +232,7 @@
       <tr id="trGrad_Plan" class="row-grad"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
         <td class="bold">Post-Graduation Plan &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]PostGradPlans" id="fieldGradPlan" value="~(PostGradPlans)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#futureplans'" class="editButton" type="button">Edit</button></td>
          <!-- DEPENDENCIES: If...
               ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate)
               ...DOE033 does not = '500', then DOE12 must = '04', '10'(Certificate), or '11'(Completed Grade 12) -->
@@ -225,6 +240,7 @@
       <tr id="trGrad_CoreCompletion" class="row-grad"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
         <td class="bold">Massachusetts Core Curriculum Completion &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]GradCompleteCoreCurriculum" id="fieldCoreCompletion" value="~(GradCompleteCoreCurriculum)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#gradstatus'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!-- Custom Fields: 'Legal Info' -->
       <tr id="trLegal_FullName" class="row-legal">
@@ -240,6 +256,8 @@
       <tr id="trLegal_Gender" class="row-legal">
         <td class="bold">Legal Gender &tilde;</td>
         <td width="75%"><input type="text" name="[Students]Gender" id="fieldLegalGender" value="~(gender)" readonly /></td>
+        <!-- Gender on SIMS page doesn't have an ID to link to, should figure out how to get link to focus on it -->
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#'" class="editButton" type="button">Edit</button></td>
       </tr>
     <!-- Custom Fields: 'Other' (LPS)  -->
       <tr id="trOther_NCLB" class="row-other other-lps"> <!-- DOE020(?) *DOE020 is for 'Title 1 participation type', this is 'Title 1 School Choice status'. Don't know what the difference is. -->
@@ -249,26 +267,32 @@
       <tr id="trOther_FirstYearEL" class="row-other other-lps"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
         <td class="bold">First Year English Learner &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEP1stYrInUS" id="fieldFirstYearEL" value="~(LEP1stYrInUS)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_LEPinUS'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_IsEL" class="row-other other-lps"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
         <td class="bold">English Learner &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency" id="fieldIsEL" value="~(LimitedEnglishProficiency)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_EngProficiency'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_ELStatus" class="row-other other-lps"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
         <td class="bold">EL Program Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEPProgramStatus" id="fieldELStatus" value="~(LEPProgramStatus)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#BilingualStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_SASID" class="row-other other-lps"> <!-- DOE002 *10 digits long, -->
         <td class="bold">State Assigned Student Identifier (SASID) &tilde;</td>
         <td width="75%"><input type="text" name="[Students]State_StudentNumber" id="fieldSASID" value="~(State_StudentNumber)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_IsImmigrant" class="row-other other-lps"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
         <td class="bold">Immigrant &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]ImmigrantStatus" id="fieldImmigrantStatus" value="~(ImmigrantStatus)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_ImmgrStatus'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_EnrollmentStatus" class="row-other other-lps"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
         <td class="bold">Enrollment Status &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]EnrollStatusTimeOfCollection" id="fieldEnrollmentStatus" value="~(EnrollStatusTimeOfCollection)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#enrollstatus'" class="editButton" type="button">Edit</button></td>
       <tr id="trOther_TransferFrom" class="row-other other-lps">
         <td class="bold">Transferring from &tilde;</td>
         <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" readonly /></td>
@@ -280,6 +304,7 @@
       <tr id="trOther_OriginCountry" class="row-other other-lps"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
         <td class="bold">Country of Origin &tilde;</td> <!-- value="500" > not an immigrant student (US Origin) -->
         <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]CountryOfOrigin" id="fieldOriginCountry" value="~(CountryOfOrigin)" readonly /></td>
+        <td><button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/USA_MA/stateMA-SIMS.html?frn=001113601#MA_Country'" class="editButton" type="button">Edit</button></td>
       </tr>
       <tr id="trOther_TeamFlag" class="row-other other-lps">
         <td class="bold">Team Flag &tilde;</td>
@@ -288,6 +313,35 @@
     </tbody>
   </table>
 
+<!-- Grouping these 3 fields in a box-round to communicate that the "Edit" button functions the same for each -->
+<div id="stateIncludeWrapper" class="row-ethRace ethrace-other">
+  <div class="button-row" style="margin:0px;padding-bottom:0px;">
+    <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/state/stateMA.html?frn=001113601'" id="editStateIncludeBtn" type="button">Edit</button>
+  </div>
+  <div class="box-round" id="stateIncludeBox">
+    <table class="linkDescList" style="margin-top:0px">
+      <colgroup>
+        <col style="width: auto">
+        <col style="width: 1920px">
+      </colgroup>
+      <tbody width="1920px">
+        <tr id="trRace_ExcludeState" class="">
+          <td class="bold">Exclude from State Reporting? &tilde;</td>
+          <td><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)" readonly /></td>
+        </tr> <!-- All "include/exclude" fields are in the same place so only need one edit button link -->
+        <tr id="trRace_IncludeSIMS" class="">
+          <td class="bold">Include in SIMS Report? &tilde;</td>
+          <td><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)" readonly /></td>
+        </tr>
+        <tr id="trRace_IncludeSASID" class="">
+          <td class="bold">Include in SASID Report? &tilde;</td>
+          <td><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)" readonly /></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+      
   <!--
     Copying Contacts page source and displaying it in Demographics 'Contacts' section.
     -Omitted <script> code from Contacts that is not relevant to Demographics
@@ -304,6 +358,7 @@
         <input type="checkbox" id="showAllChkBox" data-ng-disabled="!demoContext.hasEndDateAccess" data-ng-model="context.showAllStudentContacts" 
                data-ng-change="saveShowAllStudentContacts()" />
         <label for="showAllChkBox" data-ng-bind="getShowAllStudentContactsMessageWithCount()"></label>
+        <button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/contacts.html?frn=001113601'" id="viewContactsBtn" type="button">View Contacts Page</button>
         <!-- ~ "Add" button has been removed for Demographics ~ -->
       </div>
       <p class="feedback-info" data-ng-if="!context.contacts.length" >This student does not have any associated contacts.</p>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!-- use jQuery to replace text -->
 <script src="/admin/javascript/LPSGDC.js"></script>
-<link rel="stylesheet" type="text/css" href="/admin/styles/LPSGDC.css"></style>
+<link rel="stylesheet" type="text/css" href="/admin/styles/LPSGDC.css" />
 <!--
   NOTES:
   - In order to save input to database, <input> needs
@@ -247,13 +247,6 @@
        data-module-name="contactsModule" data-ng-cloak id="demoContactsTable">
     <!-- Start of <div controller = "contactStudentController"> : Context container for Contacts table -->
     <div data-ng-controller="contactStudentController">
-      <div class="button-row">
-        <input type="checkbox" id="showAllChkBox" data-ng-disabled="!demoContext.hasEndDateAccess" data-ng-model="context.showAllStudentContacts" 
-               data-ng-change="saveShowAllStudentContacts()" />
-        <label for="showAllChkBox" data-ng-bind="getShowAllStudentContactsMessageWithCount()"></label>
-        <!--<button onclick="location.href='https://pstest.lawrence.k12.ma.us/admin/students/contacts.html?frn=~(frn)'" id="viewContactsBtn" type="button">View Contacts Page</button>-->
-        <!-- ~ "Add" button has been removed for Demographics ~ -->
-      </div>
       <p class="feedback-info" data-ng-if="!context.contacts.length" >This student does not have any associated contacts.</p>
       <!--============================================|STUDENT_CONTACTS_TABLE|============================================-->
       <table id="studentContactsTable" class="grid" data-ng-if="context.contacts.length" >
@@ -339,8 +332,6 @@
           </td>
           <!-- "Phone" : Phone number for Contact -->
           <td class="nowrap">
-            <input id="phonenumberid-{{$index}}" name="phonenumberid[{{$index}}]" type="hidden" value="{{contact.view.firstPhone.phoneNumberId}}">
-            <input id="personphonenumberassocid-{{$index}}" name="personphonenumbersassocid[{{$index}}]" type="hidden" value="{{contact.view.firstPhone.contactsPhoneId}}">
             <span id="contact-phone-{{$index}}" data-ng-bind="contact.view.firstPhone.phoneNumber" ></span>
             <span id="contact-phoneext-{{$index}}" data-ng-bind="contact.view.firstPhone.extension !== '' && contact.view.firstPhone.extension != null ?
                   ' x' + contact.view.firstPhone.extension : ''" ></span>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -1,14 +1,71 @@
 <!-- use jQuery to replace text -->
 <script src="/admin/javascript/LPSGDC.js"></script>
 <style type="text/css">
+/* Adjust navbar for screensize */
+  @media screen and (max-width: 1200px) {
+    #demo-navbar a {
+      font-size: 13px;
+      padding: 10px;
+    }
+  }
+  @media screen and (max-width: 840px) {
+    #demo-navbar a {
+      font-size: 10px;
+      padding: 7px;
+    }
+  }
+  /* 650px is when PS stops scaling the page  */
+  @media screen and (max-width: 650px) {
+    #demo-navbar a {
+      line-height: 1.5em;
+      font-size: 7px;
+      padding: 3px;
+    }
+  }
+  /* Maybe should change this to move links to a drop-down? */
+  @media screen and (max-width: 460px) {
+    #demo-navbar a {
+      font-size: 5px;
+      line-height: 1.5em;
+      padding: 2px;
+    }
+  }
+  
+  /* Slide-down navigation bar for section anchors */
+  #demo-navbar {
+    overflow: hidden;
+    background-color: #333;
+    position: fixed;
+    top: -100px;
+    width: 100%;
+    transition: top 0.3s;
+    z-index: 1;
+  }
+  #demo-navbar a {
+    float: left;
+    display: block;
+    color: #f2f2f2;
+    text-align: center;
+    padding: 15px;
+    text-decoration: none;
+    font-size: 17px;
+  }
+  #demo-navbar a:hover {
+    background-color: #ddd;
+    color: black;
+  }
+  #demo-navbar a.active {
+    background-color: #04AA6D;
+    color: white;
+  }
+
   input:read-only {
     border-style: inset;
-    border-width: 2px; 
+    border-width: 2px;
     border-color: rgb(118,118,118) rgb(133,133,133) rgb(133,133,133) rgb(118,118,118);
     padding: 3px;
     background-color: rgb(217,217,217); /* highlight custom fields grey */
   }
-
   /* highlight fields: incomplete = red, completed = green */
   input:invalid {
     background-color: rgb(230, 179, 179);
@@ -25,33 +82,53 @@
   input:only-child {
     width: 99%;
   }
+  
+  #demoContactsSection {
+    border-style: none;
+  }
+  #studentContactsTable {
+    width: calc(100% - 20px);
+  }
 </style>
-<!-- 
+<!--
   NOTES:
-   -Can either do fields as 'disabled' or 'readonly' 
-     *I think the main difference is how it looks but maybe it changes
-       submit funcitionality. Setting as 'readonly' for now
-   -In order to save input to database, <input> needs
+  - In order to save input to database, <input> needs
      Core Fields:      name="[Table_Name]Field_Name"
      Extension Fields: name="[PrimaryTable.ExtensionGroupName]Field_Name"
-   -Using ~(Field_Name) applies a default read-only format, ~([Table_Name]Field_Name) does not 
-     
-  BUGS:
-   -Apparently adding name="[Table_Name]Field_Name" to inputs auto-adds
-     certain PS validation attributes/classes and screws up formatting 
-     when you put a field into focus
+  - Using ~(Field_Name) applies default read-only format, ~([Table_Name]Field_Name) does not
+  - Apparently adding name="[Table_Name]Field_Name" to inputs auto-adds certain PS
+     validation attributes/classes and screws up formatting when you put a field into focus
  -->
 <div id="LPS-GDCustomhiddentable" style="display: none;">
+  <nav id="demo-navbar">
+    <a href="#StudentSection" class="sectLink">Student</a>
+    <a href="#ContactsSection" class="sectLink">Contacts</a>
+    <a href="#EthRaceSection" class="sectLink">Ethnicity & Race</a>
+    <a href="#OfficeSection" class="sectLink">Administration</a>
+    <a href="#GradSection" class="sectLink">Graduation</a>
+    <a href="#LegalSection" class="sectLink">Legal</a>
+    <a href="#OtherSection" class="sectLink">Other</a>
+    <a href="#EverythingElseSection" class="sectLink">Everything Else</a>
+    <a href="#" id="expandAll">Expand All</a>
+    <a href="#" id="collapseAll">Collapse All</a>
+  </nav>
   <div class="tabs" id="demo-navTabs">
     <ul>
-      <li><a href="#StudentSection" class="sectLink">Student</a></li>
-      <li><a href="#ContactsSection" class="sectLink">Contacts</a></li>
-      <li><a href="#EthRaceSection" class="sectLink">Ethnicity & Race</a></li>
-      <li><a href="#OfficeSection" class="sectLink">Administration</a></li>
-      <li><a href="#GradSection" class="sectLink">Graduation</a></li>
-      <li><a href="#LegalSection" class="sectLink">Legal</a></li>
-      <li><a href="#OtherSection" class="sectLink">Other</a></li>
-      <li><a href="#EverythingElseSection" class="sectLink">Everything Else</a></li>
+      <!-- "Show All" option -->
+      <li> <!-- This is very broken oh lordy -->
+        <a href="#" id="demoShowAllTab" class="sectTab">
+          <input type="checkbox" id="demoShowAllCheckBox" name="demoShowAllCheckBox" value="1" checked>
+          <label>Show All (Broken)</label>
+        </a>
+      </li>
+      <li><a href="#StudentSection" class="sectTab">Student</a></li>
+      <li><a href="#ContactsSection" class="sectTab">Contacts</a></li>
+      <li><a href="#EthRaceSection" class="sectTab">Ethnicity & Race</a></li>
+      <li><a href="#OfficeSection" class="sectTab">Administration</a></li>
+      <li><a href="#GradSection" class="sectTab">Graduation</a></li>
+      <li><a href="#LegalSection" class="sectTab">Legal</a></li>
+      <li><a href="#OtherSection" class="sectTab">Other</a></li>
+      <li><a href="#EverythingElseSection" class="sectTab">Everything Else</a></li>
     </ul>
   </div>
   <table>
@@ -67,7 +144,7 @@
       </tr>
       <tr id="trStudent_LPSEmail" class="row-student student-contactInfo">
         <td class="bold">Student LPS Email &tilde;</td>
-        <td width="75%"><input type="email" id="fieldLPSEmail" value="~[tlist_sql; 
+        <td width="75%"><input type="email" id="fieldLPSEmail" value="~[tlist_sql;
           SELECT psc.Email AS email
           FROM PSM_STudentcontact psc
             JOIN PSM_StudentContactType psct ON psc.StudentContactTypeId = psct.id
@@ -78,10 +155,6 @@
             stu.student_number = ~([Students]student_number)]~(email)[/tlist_sql]"
           readonly />
         </td>
-      </tr>
-    <!--  Custom Fields: 'Guardian/Contacts Information' -->
-      <tr id="trContacts_">
-        
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
       <tr id="trRace_ExcludeState" class="row-ethRace ethrace-other">
@@ -143,9 +216,9 @@
         <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]cohort" id="fieldCohort" value="~(cohort)" placeholder="COHORT #..." readonly /></td>
       </tr>
       <tr id="trGrad_Plan" class="row-grad"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
-        <td class="bold">Post-Graduation Plan &tilde;</td> 
+        <td class="bold">Post-Graduation Plan &tilde;</td>
         <td width="75%"><input type="text" name="[Students.S_MA_STU_X]PostGradPlans" id="fieldGradPlan" value="~(PostGradPlans)" readonly /></td>
-         <!-- DEPENDENCIES: If... 
+         <!-- DEPENDENCIES: If...
               ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate)
               ...DOE033 does not = '500', then DOE12 must = '04', '10'(Certificate), or '11'(Completed Grade 12) -->
       </tr>
@@ -200,7 +273,7 @@
         <td class="bold">Transferring from &tilde;</td>
         <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" readonly /></td>
       </tr>
-      <tr id="trOther_BirthState" class="row-other other-lps"> 
+      <tr id="trOther_BirthState" class="row-other other-lps">
         <td class="bold">Birth State &tilde;</td>
         <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]MA_BirthState" id="fieldBirthState" value="~(MA_BirthState)" readonly /></td>
       </tr>
@@ -214,4 +287,270 @@
       </tr>
     </tbody>
   </table>
+
+  <!--
+    Copying Contacts page source and displaying it in Demographics 'Contacts' section.
+    -Omitted <script> code from Contacts that is not relevant to Demographics
+    -Removed unnecessary form elements (Add/Delete/Edit)
+    -Assuming Contacts form was properly validated when filled out, simply retrieve & display data
+  --> 
+  <!-- Start of Content & Bounding box <div controller = "studentPageContactsController"> : *Required* - used by Angular -->
+  <div class="box-round" data-ng-controller="studentPageContactsController"
+       data-require-path="components/contacts/index,components/widgets/dirtyInputHelper/index"
+       data-module-name="contactsModule" data-ng-cloak id="demoContactsSection">
+    <!-- Start of <div controller = "contactStudentController"> : Context container for Contacts table -->
+    <div data-ng-controller="contactStudentController">
+      <div class="button-row">
+        <input type="checkbox" id="showAllChkBox" data-ng-disabled="!demoContext.hasEndDateAccess" data-ng-model="context.showAllStudentContacts" 
+               data-ng-change="saveShowAllStudentContacts()" />
+        <label for="showAllChkBox" data-ng-bind="getShowAllStudentContactsMessageWithCount()"></label>
+        <!-- ~ "Add" button has been removed for Demographics ~ -->
+      </div>
+      <p class="feedback-info" data-ng-if="!context.contacts.length" >This student does not have any associated contacts.</p>
+      <!--============================================|STUDENT_CONTACTS_TABLE|============================================-->
+      <table id="studentContactsTable" class="grid" data-ng-if="context.contacts.length" >
+        <colgroup>
+     <!-- <col style="width: auto"> - Removed -->
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+          <col style="width: auto">
+     <!-- <col style="width: 1%"> - Removed -->
+        </colgroup>
+        <tr>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.name_email]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.relationship]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.phone_type]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.phone]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.address]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.custody]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.lives_with]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.school_pickup]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.emergency_contact]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.original_contact_type]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.start_date]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.end_date]</th>
+          <th>~[text:psx.html.admin_students.unlimitedcontacts.data_access]</th>
+        </tr>
+        <!-- Uses AngularJS to create <tr> element for each contact -->
+        <tr data-ng-repeat="contact in context.contacts | filter: !context.showAllStudentContacts ? {contactStudents: {current: true}} : {} | 
+            orderBy:'contactStudents[0].sequence'"
+            class="center" data-ng-style="!contact.contactStudents[0].current && {'font-style':'italic'}">
+          <!-- ~ "Order" column has been removed for demographics ~ -->
+          <!-- "Name / Email" : Contact's full name + email address  -->
+          <td class="nowrap left" >
+          
+            <!--============================================|LINK TO "EDIT_CONTACTS" PAGE : BOOKMARKING FOR LATER|============================================-->
+            <!-- Has Name: let FLS do it's thing --> 
+            <a data-ng-href="/admin/contacts/edit.html#?contactid={{contact.contactId}}" target="_blank" data-ng-if="contact.firstName || contact.lastName">
+              <span id="contact-first-name-{{$index}}" data-ng-bind="contact.firstName" ></span>
+              <span id="contact-last-name-{{$index}}" data-ng-bind="contact.lastName" ></span>
+            </a>
+            <!--============================================|LINK TO "EDIT_CONTACTS" PAGE : BOOKMARKING FOR LATER|============================================-->
+            
+            <span data-ng-if="!contact.firstName && !contact.lastName">
+              <!-- No Name: distinguish between no access and some access -->
+              ~[if#FNACCESS.security.fieldLevel=PERSON.FIRSTNAME=NOACCESS]
+                ~[if#LNACCESS.security.fieldLevel=PERSON.LASTNAME=NOACCESS]
+                  <!-- No Access: print fls mask with out anchor-->
+                  <span>~[text:psx.html.admin_students.unlimitedcontacts.fls_mask]</span>
+                [else#LNACCESS]
+                  <!-- Some Access: print no name with anchor -->
+                  <a data-ng-href="/admin/contacts/edit.html#?contactid={{contact.contactId}}" target="_blank">
+                    ~[text:psx.html.admin_students.unlimitedcontacts.no_name]{{contact.contactId}}
+                  </a>
+                [/if#LNACCESS]
+              [else#FNACCESS]
+                <!-- Some Access: print no name with anchor -->
+                <a data-ng-href="/admin/contacts/edit.html#?contactid={{contact.contactId}}" target="_blank">
+                  ~[text:psx.html.admin_students.unlimitedcontacts.no_name]{{contact.contactId}}
+                </a>
+              [/if#FNACCESS]
+            </span>
+            <br />
+            <input id="personemailaddressassocid-{{$index}}" name="personemailaddressassocid[{{$index}}]" type="hidden" value="{{contact.view.preferredEmail.contactEmailId}}">
+            <input id="emailaddresid-{{$index}}" name="emailaddressid[{{$index}}]" type="hidden" value="{{contact.view.preferredEmail.emailId}}">
+            <span id="contact-email-{{$index}}" data-ng-if="contact.view.preferredEmail.address" data-ng-bind="'<' + contact.view.preferredEmail.address + '>'" ></span>
+          </td>
+          <!-- "Relationship" : How Contact is related to Student -->
+          <td>
+            <span id="contact-relationshiptype-{{$index}}" data-ng-bind="relationshipTypeCodeSetLookup[contact.contactStudents[0].activeDetail.relationship].value" ></span>
+          </td>
+          <!-- "Phone Type" : Mobile, Home, Work... -->
+          <td>
+            <span id="contact-phonetype-{{$index}}" data-ng-bind="phoneTypeCodeSetLookup[contact.view.firstPhone.phoneType].value" ></span>
+          </td>
+          <!-- "Phone" : Phone number for Contact -->
+          <td class="nowrap">
+            <input id="phonenumberid-{{$index}}" name="phonenumberid[{{$index}}]" type="hidden" value="{{contact.view.firstPhone.phoneNumberId}}">
+            <input id="personphonenumberassocid-{{$index}}" name="personphonenumbersassocid[{{$index}}]" type="hidden" value="{{contact.view.firstPhone.contactsPhoneId}}">
+            <span id="contact-phone-{{$index}}" data-ng-bind="contact.view.firstPhone.phoneNumber" ></span>
+            <span id="contact-phoneext-{{$index}}" data-ng-bind="contact.view.firstPhone.extension !== '' && contact.view.firstPhone.extension != null ?
+                  ' x' + contact.view.firstPhone.extension : ''" ></span>
+          </td>
+          <!-- "Address" : Home Address of Contact -->
+          <td class="nowrap left" >
+            <div id="contact-physical-address-{{$index}}">
+              <span data-ng-bind="contact.view.firstAddress.street" ></span>
+              <span data-ng-if="contact.view.firstAddress.unit.length" data-ng-bind="' ' + contact.view.firstAddress.unit"></span>
+              <br/>
+              <div data-ng-if="contact.view.firstAddress.linetwo.length">
+                <span data-ng-bind="contact.view.firstAddress.linetwo" ></span>
+                <br/>
+              </div>
+              <div data-ng-if="contact.view.firstAddress.city || stateCodesetDisplayMap[contact.view.firstAddress.state].code || contact.view.firstAddress.postalcode">
+                <!-- only append comma if both city and state are present. -->
+                <span data-ng-if="contact.view.firstAddress.city && stateCodesetDisplayMap[contact.view.firstAddress.state].code">
+                  <span data-ng-bind="contact.view.firstAddress.city"></span>,
+                </span>
+                <span data-ng-if="!contact.view.firstAddress.city || !stateCodesetDisplayMap[contact.view.firstAddress.state].code">
+                  <span data-ng-bind="contact.view.firstAddress.city"></span>
+                </span>
+                <span data-ng-bind="stateCodesetDisplayMap[contact.view.firstAddress.state].code"></span>
+                <span data-ng-bind="contact.view.firstAddress.postalcode"></span>
+              </div>
+            </div>
+            <input id="personaddressassocid-{{$index}}" name="personaddressassocid[{{$index}}]" type="hidden" value="{{contact.view.firstAddress.contactsAddressId}}">
+            <input id="personaddresid-{{$index}}" name="personaddressid[{{$index}}]" type="hidden" value="{{contact.view.firstAddress.addressId}}">
+          </td>
+          <!-- "Custody" : Does Contact have legal Custody? [x] => Y, [ ] => N -->
+          <td data-ng-class="{'checkmark-icon': contact.contactStudents[0].activeDetail.custodial}">
+            <center><em id="contact-custody-{{$index}}"></em></center>
+          </td>
+          <!-- "Lives With" : Does Student currently live with Contact? [ ] => Y, [ ] => N -->
+          <td data-ng-class="{'checkmark-icon': contact.contactStudents[0].activeDetail.livesWith}">
+            <center><em id="contact-livesWith-{{$index}}"></em></center>
+          </td>
+          <!-- 
+            "School Pickup" : Is Contact allowed(?) to pickup Student from school? [ ] = Y, [x] = N   
+             -I assume since no flags are set that it only gets set if there is an issue
+          -->
+          <td data-ng-class="{'checkmark-icon': contact.contactStudents[0].activeDetail.schoolPickup}">
+            <center><em id="contact-schoolPickup-{{$index}}"></em></center>
+          </td>
+          <!-- "Emerg. Contact" : Is Contact an Emerg. Contact? [x] = Y, [ ] = N -->
+          <td data-ng-class="{'checkmark-icon': contact.contactStudents[0].activeDetail.emergency}">
+            <center><em id="contact-emergency-{{$index}}"></em></center>
+          </td>
+          <!-- "Original Contact Type" column : Idk what this is for but it does what it says -->
+          <td>
+            <span id="contact-originalcontacttype-{{$index}}" data-ng-bind="contact.contactStudents[0].originalContactType.value" 
+                  name="relationship-originalcontacttype-display-{{$index}}" ></span>
+          </td>
+          <!-- "Start Date" : Field is empty for most Contacts, presumably for temp Contacts -->
+          <td>
+            <span id="contact-startDate-{{$index}}" data-ng-bind="localizedDate(contact.contactStudents[0].activeDetail.startDate)"></span>
+          </td>
+          <!-- "End Date" : Field is empty for most Contacts, presumably for temp Contacts -->
+          <td>
+            <span id="contact-endDate-{{$index}}" data-ng-bind="localizedDate(contact.contactStudents[0].activeDetail.endDate)"></span>
+          </td>
+          <!-- "Data Access" : Does Contact have access Student data? [x] => Y, [ ] => N -->
+          <td data-ng-class="{'checkmark-icon': contact.contactStudents[0].canAccessData}">
+            <center><em id="contact-data-access-{{$index}}" ></em></center>
+          </td>
+          <!-- ~ "Actions" column has been removed for demographics ~ -->
+        </tr>
+      </table>
+      <!--============================================|STUDENT_CONTACTS_TABLE_END|============================================-->
+    </div>
+    <script> var _curSchoolNumber = 0; </script>
+    <div class="hidden">
+      <input id="studentDcid" type="hidden" value="113601" />
+      <input id="schoolId" type="hidden" value="0" />
+      <input id="studentNumber" type="hidden" value="111308" />
+    </div>
+  </div>
+
+  <!-- Comment Form -->
+  <div class="box-round" id="demoComments">
+    <div class="tlistCollectionTable tlistCollectionTableInitialized">
+      <div class="button-row">
+        <button type="button" id="addButton">Add</button>
+      </div>
+      <table class="grid">
+        <colgroup>
+          <col class="col-COMMENT_DATE">
+          <col class="col-COMMENT_REASON">
+          <col class="col-COMMENT_PERSON">
+          <col class="col-COMMENT_COMMENT">
+          <col class="col-delete">
+        </colgroup>
+        <thead>
+          <tr>
+            <th>Date of Comment</th>
+            <th>Reason for Comment</th>
+            <th>Person Making Change</th>
+            <th>Comment</th>
+            <th>Delete</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="rowId_52412">
+            <td id="COMMENT_DATE_52412" class="td-COMMENT_DATE">
+              <b class="dpWrapper">
+                <input type="text" class="COMMENT_DATE psDateWidget unvalidated hasDatepicker" value="03/26/2019"
+                       data-validation="{&quot;type&quot;:&quot;date&quot;,&quot;key&quot;:&quot;students.u_comment.comment_date&quot;}"
+                       name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:52412]COMMENT_DATE$format=date" data-key="students.u_comment.comment_date" id="dp1625588312868" placeholder="MM/DD/YYYY">
+                <button type="button" class="ui-datepicker-trigger" aria-hidden="true" tabindex="-1"></button>
+              </b>
+            </td>
+            <td id="COMMENT_REASON_52412" class="td-COMMENT_REASON">
+              <input type="text" class="COMMENT_REASON psTextWidget" value="TransferFrom-Original" maxlength="25"
+                     data-validation="{&quot;maxlength&quot;:&quot;25&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_reason&quot;}"
+                     name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:52412]COMMENT_REASON" data-key="students.u_comment.comment_reason" id="ldv_generatedID1">
+            </td>
+            <td id="COMMENT_PERSON_52412" class="td-COMMENT_PERSON">
+              <input type="text" class="COMMENT_PERSON psTextWidget unvalidated" value="DC" maxlength="2"
+                     data-validation="{&quot;maxlength&quot;:&quot;2&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_person&quot;}"
+                     name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:52412]COMMENT_PERSON" data-key="students.u_comment.comment_person">
+            </td>
+            <td id="COMMENT_COMMENT_52412" class="td-COMMENT_COMMENT">
+              <input type="text" class="COMMENT_COMMENT psTextWidget unvalidated" value="GLCA" maxlength="500"
+                     data-validation="{&quot;maxlength&quot;:&quot;500&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_comment&quot;}"
+                     name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:52412]COMMENT_COMMENT" data-key="students.u_comment.comment_comment">
+            </td>
+            <td>
+              <input class="deleteCB hide" name="DC-STUDENTS:113601.U_COMMENT.U_COMMENT:52412" type="checkbox">
+              <button class="undoDelRow hide" type="button"><em>&nbsp;</em></button>
+              <button class="deleteRow" type="button"><em>&nbsp;</em></button>
+            </td>
+          </tr>
+          <tr class="new">
+            <td id="COMMENT_DATE_-{INSERT_COUNTER}" class="td-COMMENT_DATE">
+              <input type="text" class="COMMENT_DATE" data-addclass="psDateWidget" value=""
+                     data-validation-add="{&quot;type&quot;:&quot;date&quot;,&quot;key&quot;:&quot;students.u_comment.comment_date&quot;}"
+                     data-name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:-{INSERT_COUNTER}]COMMENT_DATE$format=date">
+            </td>
+            <td id="COMMENT_REASON_-{INSERT_COUNTER}" class="td-COMMENT_REASON">
+              <input type="text" class="COMMENT_REASON" data-addclass="psTextWidget" maxlength="25" value=""
+                     data-validation-add="{&quot;maxlength&quot;:&quot;25&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_reason&quot;}"
+                     data-name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:-{INSERT_COUNTER}]COMMENT_REASON">
+            </td>
+            <td id="COMMENT_PERSON_-{INSERT_COUNTER}" class="td-COMMENT_PERSON">
+              <input type="text" class="COMMENT_PERSON" data-addclass="psTextWidget" maxlength="2" value=""
+                     data-validation-add="{&quot;maxlength&quot;:&quot;2&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_person&quot;}"
+                     data-name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:-{INSERT_COUNTER}]COMMENT_PERSON">
+            </td>
+            <td id="COMMENT_COMMENT_-{INSERT_COUNTER}" class="td-COMMENT_COMMENT">
+              <input type="text" class="COMMENT_COMMENT" data-addclass="psTextWidget" maxlength="500" value=""
+                     data-validation-add="{&quot;maxlength&quot;:&quot;500&quot;,&quot;type&quot;:&quot;text&quot;,&quot;key&quot;:&quot;students.u_comment.comment_comment&quot;}"
+                     data-name="CF-[STUDENTS:113601.U_COMMENT.U_COMMENT:-{INSERT_COUNTER}]COMMENT_COMMENT">
+            </td>
+            <td class="deleteCol"></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  
 </div>

--- a/WEB_ROOT/admin/students/more2.LPSGDC.leftnav.footer.txt
+++ b/WEB_ROOT/admin/students/more2.LPSGDC.leftnav.footer.txt
@@ -1,0 +1,18 @@
+    <style>
+      a.LPSECTA:link {
+        color: red;
+      }
+      a.LPSECTA:visited {
+        color: red;
+      }
+      a.LPSECTA:hover {
+        color: red;
+      }
+      }
+    </style>
+<script type="text/javascript">
+$j(document).ready(function() {
+$j( "ul#std_information > li > a[href^='generaldemographics.html?frn=']" ).parent().replaceWith( $j('<li><a class="LPSGDC" href="generaldemographics.html?frn=~(studentfrn)#TabView">General Demographics - Tabs &tilde;</a></li>') );
+$j( "ul#std_information > li > a[href^='generaldemographics.html?frn=']" ).parent().after($j('<li ><a class="LPSGDC" href="generaldemographics.html?frn=~(studentfrn)#CollapsedView">General Demographics - Collapsed &tilde;</a></li>'));
+});
+</script>

--- a/WEB_ROOT/admin/students/more2.LPSGDC.leftnav.footer.txt
+++ b/WEB_ROOT/admin/students/more2.LPSGDC.leftnav.footer.txt
@@ -13,6 +13,6 @@
 <script type="text/javascript">
 $j(document).ready(function() {
 $j( "ul#std_information > li > a[href^='generaldemographics.html?frn=']" ).parent().replaceWith( $j('<li><a class="LPSGDC" href="generaldemographics.html?frn=~(studentfrn)#TabView">General Demographics - Tabs &tilde;</a></li>') );
-$j( "ul#std_information > li > a[href^='generaldemographics.html?frn=']" ).parent().after($j('<li ><a class="LPSGDC" href="generaldemographics.html?frn=~(studentfrn)#CollapsedView">General Demographics - Collapsed &tilde;</a></li>'));
+$j( "ul#std_information > li > a[href^='generaldemographics.html?frn=']" ).parent().after($j('<li ><a class="LPSGDC" href="generaldemographics.html?frn=~(studentfrn)#CollapseView">General Demographics - Collapsed &tilde;</a></li>'));
 });
 </script>

--- a/WEB_ROOT/admin/students/more2.LPSGDC.leftnav.footer.txt
+++ b/WEB_ROOT/admin/students/more2.LPSGDC.leftnav.footer.txt
@@ -1,18 +1,24 @@
-    <style>
-      a.LPSECTA:link {
-        color: red;
-      }
-      a.LPSECTA:visited {
-        color: red;
-      }
-      a.LPSECTA:hover {
-        color: red;
-      }
-      }
-    </style>
+<style>
+  a.LPSGDC:link {
+    color: red;
+  }
+  a.LPSGDC:visited {
+    color: red;
+  }
+  a.LPSGDC:hover {
+    color: red;
+  }
+</style>
 <script type="text/javascript">
 $j(document).ready(function() {
-$j( "ul#std_information > li > a[href^='generaldemographics.html?frn=']" ).parent().replaceWith( $j('<li><a class="LPSGDC" href="generaldemographics.html?frn=~(studentfrn)#TabView">General Demographics - Tabs &tilde;</a></li>') );
-$j( "ul#std_information > li > a[href^='generaldemographics.html?frn=']" ).parent().after($j('<li ><a class="LPSGDC" href="generaldemographics.html?frn=~(studentfrn)#CollapseView">General Demographics - Collapsed &tilde;</a></li>'));
+    var originalGD = $j( "ul#std_information > li > a[href^='generaldemographics.html?frn=']" );
+    originalGD.parent().after($j('<li ><a class="LPSGDC" href="generaldemographics.html?frn=~(studentfrn)#TabView">General Demographics - Tabs &tilde;</a></li>'));
+    originalGD.replaceWith( $j('<a class="LPSGDC" href="generaldemographics.html?frn=~(studentfrn)#CollapseView">General Demographics - Collapsed &tilde;</a>') );
+    
+    $j(".LPSGDC").on("click", function(event) { 
+      window.parent.frames[1].location.hash = event.target.hash;
+      window.parent.frames[1].location.reload();
+      
+    });
 });
 </script>

--- a/WEB_ROOT/admin/styles/LPSGDC.css
+++ b/WEB_ROOT/admin/styles/LPSGDC.css
@@ -1,118 +1,49 @@
-/* highlight fields: incomplete = red, completed = green !!FOR BUG-FINDING/FIXING ONLY!! */
-/*
-input:invalid {
-  background-color: rgb(230, 179, 179);
+#pds-header > header {
+  flex: 1 0 25% !important;
 }
-input:placeholder-shown {
-  background-color: rgb(230, 179, 179);
+.pds-app-header-bar-center {
+  flex: 1 1 50% !important;
 }
-input:valid {
-  background-color: rgb(179, 230, 179);
-}
-input.noValue {
-  background-color: rgb(230, 179, 179);
-}
-*/
-
-/* Adjust navbar for screensize */
-@media screen and (max-width: 1200px) {
-  #demoNavBar a {
-    font-size: 13px;
-    padding: 10px;
-  }
-}
-@media screen and (max-width: 840px) {
-  #demoNavBar a {
-    font-size: 10px;
-    padding: 7px;
-  }
-}
-/* 650px is when PS stops scaling the page  */
-@media screen and (max-width: 650px) {
-  #demoNavBar a {
-    line-height: 1.5em;
-    font-size: 7px;
-    padding: 3px;
-  }
-}
-/* Maybe should change this to move links to a drop-down? */
-@media screen and (max-width: 460px) {
-  #demoNavBar a {
-    font-size: 5px;
-    line-height: 1.5em;
-    padding: 2px;
-  }
-}
-
-/* Style headers to match other PS pages */
-.collapsed {
-  background-color: rgb(237, 237, 237);
-}
-.expanded {
-  background-color: rgb(163, 191, 204);
+.pds-app-actions {
+  flex: 1 0 25% !important;
 }
 
 /* Slide-down navigation bar for section anchors */
 #demoNavBar {
-  position: fixed;
-  top: -100px;
-  width: 100%;
-  transition: top 0.3s;
-  overflow: hidden;
-  background-color: #333;
+  top: 0;
+  display: inline-flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  align-content: center;
+  width: auto;
+  min-height: 0;
+  max-width: 100%;
+  max-height: 100%;
+  background-color: #ed9f55;
   z-index: 1;
 }
 #demoNavBar a {
-  float: left;
-  display: block;
-  color: #f2f2f2;
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 0.5em;
+  color: rgb(0, 0, 0);
   text-align: center;
-  padding: 15px;
   text-decoration: none;
-  font-size: 17px;
+  font-weight: bold;
+  vertical-align: middle;
+  min-width: 0;
+  min-height: 0;
+  width: auto;
 }
 #demoNavBar a:hover {
-  background-color: #ddd;
-  color: black;
-}
-#demoNavBar a.active {
-  background-color: #04AA6D;
+  background-color: #fdaf65;
   color: white;
 }
-
-#navToggleBox {
-  position: fixed;
-  top: -50px;
-  right: 50%;
-  width: 5%;
-  transition: top 0.2s ease 0.1;
-  overflow: hidden;
-  background-color: transparent;
-  z-index: 1;
-}
-#navToggleBox a {
-  display: block;
-  color: #f2f2f2;
-  margin: 0 !important; 
-  text-align: center;
-  padding: 10px;
-  text-decoration: none;
-  width: auto;
-  font-size: 17px;
-}
-#navToggleBox a:hover {
-  background-color: #ddd;
-  color: black;
-}
-#navToggleBox a.active {
-  background-color: #04AA6D;
+#demoNavBar .active {
+  background-color: #dd8f45;
   color: white;
-}
-#navToggleBox button {
-  padding: 0;
-  width: 100%;
-  margin: 0;
-  line-height: 0.8em;
 }
 
 /* Make inputs look normal */
@@ -131,6 +62,13 @@ input:only-child { width: 99%; }
   width: 100%;
 }
 
-#stateIncludeBox { margin: 0; }  
+/* Style headers to match other PS pages */
+.collapsed {
+  background-color: rgb(237, 237, 237);
+}
+.expanded {
+  background-color: rgb(163, 191, 204);
+}
+
 #demoContactsTable { border-style: none; }
 #studentContactsTable { width: calc(100% - 20px); }

--- a/WEB_ROOT/admin/styles/LPSGDC.css
+++ b/WEB_ROOT/admin/styles/LPSGDC.css
@@ -19,7 +19,7 @@
   min-height: 0;
   max-width: 100%;
   max-height: 100%;
-  background-color: #ed9f55;
+  background-color: rgb(163, 191, 204);
   z-index: 1;
 }
 #demoNavBar a {
@@ -36,13 +36,17 @@
   min-width: 0;
   min-height: 0;
   width: auto;
+  border-top: 2px solid rgb(143, 171, 284);
+  border-right: 2px solid rgb(183, 211, 224);
+  border-bottom: 2px solid rgb(183, 211, 224);
+  border-left: 2px solid rgb(143, 171, 284);
 }
 #demoNavBar a:hover {
-  background-color: #fdaf65;
+  background-color: rgb(183, 211, 224);
   color: white;
 }
 #demoNavBar .active {
-  background-color: #dd8f45;
+  background-color: rgb(143, 171, 284);
   color: white;
 }
 

--- a/WEB_ROOT/admin/styles/LPSGDC.css
+++ b/WEB_ROOT/admin/styles/LPSGDC.css
@@ -1,140 +1,136 @@
 /* highlight fields: incomplete = red, completed = green !!FOR BUG-FINDING/FIXING ONLY!! */
-  /*
-  input:invalid {
-    background-color: rgb(230, 179, 179);
-  }
-  input:placeholder-shown {
-    background-color: rgb(230, 179, 179);
-  }
-  input:valid {
-    background-color: rgb(179, 230, 179);
-  }
-  input.noValue {
-    background-color: rgb(230, 179, 179);
-  }
-  */
-/* Adjust navbar for screensize */
-  @media screen and (max-width: 1200px) {
-    #demoNavBar a {
-      font-size: 13px;
-      padding: 10px;
-    }
-  }
-  @media screen and (max-width: 840px) {
-    #demoNavBar a {
-      font-size: 10px;
-      padding: 7px;
-    }
-  }
-  /* 650px is when PS stops scaling the page  */
-  @media screen and (max-width: 650px) {
-    #demoNavBar a {
-      line-height: 1.5em;
-      font-size: 7px;
-      padding: 3px;
-    }
-  }
-  /* Maybe should change this to move links to a drop-down? */
-  @media screen and (max-width: 460px) {
-    #demoNavBar a {
-      font-size: 5px;
-      line-height: 1.5em;
-      padding: 2px;
-    }
-  }
-  
-  /* Style headers to match other PS pages */
-  h2.toggle.collapsed {
-    background-color: rgb(237, 237, 237);
-  }
-  h2.toggle.expanded {
-    background-color: rgb(163, 191, 204);
-  }
-  
-/* Slide-down navigation bar for section anchors */
-  #demoNavBar {
-    position: fixed;
-    top: -100px;
-    width: 100%;
-    transition: top 0.3s;
-    overflow: hidden;
-    background-color: #333;
-    z-index: 1;
-  }
-  #demoNavBar a {
-    float: left;
-    display: block;
-    color: #f2f2f2;
-    text-align: center;
-    padding: 15px;
-    text-decoration: none;
-    font-size: 17px;
-  }
-  #demoNavBar a:hover {
-    background-color: #ddd;
-    color: black;
-  }
-  #demoNavBar a.active {
-    background-color: #04AA6D;
-    color: white;
-  }
+/*
+input:invalid {
+  background-color: rgb(230, 179, 179);
+}
+input:placeholder-shown {
+  background-color: rgb(230, 179, 179);
+}
+input:valid {
+  background-color: rgb(179, 230, 179);
+}
+input.noValue {
+  background-color: rgb(230, 179, 179);
+}
+*/
 
-  #navToggleBox {
-    position: fixed;
-    top: -50px;
-    right: 50%;
-    width: 5%;
-    transition: top 0.2s ease 0.1;
-    overflow: hidden;
-    background-color: transparent;
-    z-index: 1;
-  }
-  #navToggleBox a {
-    display: block;
-    color: #f2f2f2;
-    margin: 0px !important; 
-    text-align: center;
+/* Adjust navbar for screensize */
+@media screen and (max-width: 1200px) {
+  #demoNavBar a {
+    font-size: 13px;
     padding: 10px;
-    text-decoration: none;
-    width: auto;
-    font-size: 17px;
   }
-  #navToggleBox a:hover {
-    background-color: #ddd;
-    color: black;
+}
+@media screen and (max-width: 840px) {
+  #demoNavBar a {
+    font-size: 10px;
+    padding: 7px;
   }
-  #navToggleBox a.active {
-    background-color: #04AA6D;
-    color: white;
-  }
-  #navToggleBox button {
-    padding: 0px;
-    width: 100%;
-    margin: 0%;
-    line-height: 0.8em;
-  }
-  
-/* Make read-only inputs look normal */
-  input:read-only {
-    border-style: inset;
-    border-width: 2px;
-    border-color: rgb(118,118,118) rgb(133,133,133) rgb(133,133,133) rgb(118,118,118);
+}
+/* 650px is when PS stops scaling the page  */
+@media screen and (max-width: 650px) {
+  #demoNavBar a {
+    line-height: 1.5em;
+    font-size: 7px;
     padding: 3px;
-    background-color: rgb(255,255,255);
-    /*background-color: rgb(217,217,217); /* highlight custom fields grey !!FOR BUG-FINDING/FIXING ONLY!! */
   }
-  
-  input:only-child { width: 99%; }
-  
-  .editButton { float: right; }
-  
-  #editStateIncludeBtn { margin-top: 0px; }
-  
-  #stateIncludeBox {
-    margin-left: 0px;
-    margin-right: 0px;
-    margin-bottom: 0px;
+}
+/* Maybe should change this to move links to a drop-down? */
+@media screen and (max-width: 460px) {
+  #demoNavBar a {
+    font-size: 5px;
+    line-height: 1.5em;
+    padding: 2px;
   }
-  
-  #demoContactsTable { border-style: none; }
-  #studentContactsTable { width: calc(100% - 20px); }
+}
+
+/* Style headers to match other PS pages */
+.collapsed {
+  background-color: rgb(237, 237, 237);
+}
+.expanded {
+  background-color: rgb(163, 191, 204);
+}
+
+/* Slide-down navigation bar for section anchors */
+#demoNavBar {
+  position: fixed;
+  top: -100px;
+  width: 100%;
+  transition: top 0.3s;
+  overflow: hidden;
+  background-color: #333;
+  z-index: 1;
+}
+#demoNavBar a {
+  float: left;
+  display: block;
+  color: #f2f2f2;
+  text-align: center;
+  padding: 15px;
+  text-decoration: none;
+  font-size: 17px;
+}
+#demoNavBar a:hover {
+  background-color: #ddd;
+  color: black;
+}
+#demoNavBar a.active {
+  background-color: #04AA6D;
+  color: white;
+}
+
+#navToggleBox {
+  position: fixed;
+  top: -50px;
+  right: 50%;
+  width: 5%;
+  transition: top 0.2s ease 0.1;
+  overflow: hidden;
+  background-color: transparent;
+  z-index: 1;
+}
+#navToggleBox a {
+  display: block;
+  color: #f2f2f2;
+  margin: 0 !important; 
+  text-align: center;
+  padding: 10px;
+  text-decoration: none;
+  width: auto;
+  font-size: 17px;
+}
+#navToggleBox a:hover {
+  background-color: #ddd;
+  color: black;
+}
+#navToggleBox a.active {
+  background-color: #04AA6D;
+  color: white;
+}
+#navToggleBox button {
+  padding: 0;
+  width: 100%;
+  margin: 0;
+  line-height: 0.8em;
+}
+
+/* Make inputs look normal */
+input[type="text"], input[type="email"], input[type="password"], input[type="tel"], textarea, select {
+  border-style: inset;
+  border-width: 2px;
+  border-color: rgb(118,118,118) rgb(133,133,133) rgb(133,133,133) rgb(118,118,118);
+  padding: 3px;
+  background-color: rgb(255,255,255);
+  /*background-color: rgb(217,217,217); /* highlight custom fields grey !!FOR BUG-FINDING/FIXING ONLY!! */
+}
+input:only-child { width: 99%; }
+
+.row > table {
+  margin: 0;
+  width: 100%;
+}
+
+#stateIncludeBox { margin: 0; }  
+#demoContactsTable { border-style: none; }
+#studentContactsTable { width: calc(100% - 20px); }

--- a/WEB_ROOT/admin/styles/LPSGDC.css
+++ b/WEB_ROOT/admin/styles/LPSGDC.css
@@ -1,0 +1,140 @@
+/* highlight fields: incomplete = red, completed = green !!FOR BUG-FINDING/FIXING ONLY!! */
+  /*
+  input:invalid {
+    background-color: rgb(230, 179, 179);
+  }
+  input:placeholder-shown {
+    background-color: rgb(230, 179, 179);
+  }
+  input:valid {
+    background-color: rgb(179, 230, 179);
+  }
+  input.noValue {
+    background-color: rgb(230, 179, 179);
+  }
+  */
+/* Adjust navbar for screensize */
+  @media screen and (max-width: 1200px) {
+    #demoNavBar a {
+      font-size: 13px;
+      padding: 10px;
+    }
+  }
+  @media screen and (max-width: 840px) {
+    #demoNavBar a {
+      font-size: 10px;
+      padding: 7px;
+    }
+  }
+  /* 650px is when PS stops scaling the page  */
+  @media screen and (max-width: 650px) {
+    #demoNavBar a {
+      line-height: 1.5em;
+      font-size: 7px;
+      padding: 3px;
+    }
+  }
+  /* Maybe should change this to move links to a drop-down? */
+  @media screen and (max-width: 460px) {
+    #demoNavBar a {
+      font-size: 5px;
+      line-height: 1.5em;
+      padding: 2px;
+    }
+  }
+  
+  /* Style headers to match other PS pages */
+  h2.toggle.collapsed {
+    background-color: rgb(237, 237, 237);
+  }
+  h2.toggle.expanded {
+    background-color: rgb(163, 191, 204);
+  }
+  
+/* Slide-down navigation bar for section anchors */
+  #demoNavBar {
+    position: fixed;
+    top: -100px;
+    width: 100%;
+    transition: top 0.3s;
+    overflow: hidden;
+    background-color: #333;
+    z-index: 1;
+  }
+  #demoNavBar a {
+    float: left;
+    display: block;
+    color: #f2f2f2;
+    text-align: center;
+    padding: 15px;
+    text-decoration: none;
+    font-size: 17px;
+  }
+  #demoNavBar a:hover {
+    background-color: #ddd;
+    color: black;
+  }
+  #demoNavBar a.active {
+    background-color: #04AA6D;
+    color: white;
+  }
+
+  #navToggleBox {
+    position: fixed;
+    top: -50px;
+    right: 50%;
+    width: 5%;
+    transition: top 0.2s ease 0.1;
+    overflow: hidden;
+    background-color: transparent;
+    z-index: 1;
+  }
+  #navToggleBox a {
+    display: block;
+    color: #f2f2f2;
+    margin: 0px !important; 
+    text-align: center;
+    padding: 10px;
+    text-decoration: none;
+    width: auto;
+    font-size: 17px;
+  }
+  #navToggleBox a:hover {
+    background-color: #ddd;
+    color: black;
+  }
+  #navToggleBox a.active {
+    background-color: #04AA6D;
+    color: white;
+  }
+  #navToggleBox button {
+    padding: 0px;
+    width: 100%;
+    margin: 0%;
+    line-height: 0.8em;
+  }
+  
+/* Make read-only inputs look normal */
+  input:read-only {
+    border-style: inset;
+    border-width: 2px;
+    border-color: rgb(118,118,118) rgb(133,133,133) rgb(133,133,133) rgb(118,118,118);
+    padding: 3px;
+    background-color: rgb(255,255,255);
+    /*background-color: rgb(217,217,217); /* highlight custom fields grey !!FOR BUG-FINDING/FIXING ONLY!! */
+  }
+  
+  input:only-child { width: 99%; }
+  
+  .editButton { float: right; }
+  
+  #editStateIncludeBtn { margin-top: 0px; }
+  
+  #stateIncludeBox {
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-bottom: 0px;
+  }
+  
+  #demoContactsTable { border-style: none; }
+  #studentContactsTable { width: calc(100% - 20px); }

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation='http://plugin.powerschool.pearson.com plugin.xsd'
         name="LPS General Demographics"
-        version="0.9"
+        version="0.9.1"
         description="customize General Demographics page">
     <publisher name="Logan Arias">
     <contact email="Logan.Arias@lawrence.k12.ma.us"/>


### PR DESCRIPTION
### **CHANGELOG HISTORY:**
---
_8-4-21_
**CHANGES:**
- View style now decided at load-time via a hash in the URL
- Added links to each view in side menu navigation
- Navbar now better conforms to PowerSchool's theme
- Navbar is now a flexbox
- Fixed comment form & contacts table being hardcoded instead of changing per-student
---
_7-19-21_
**CHANGES:**
- A lot of small JavaScript optimizations
- Implemented Contacts Table (_Copied from Contacts page_)
- Implemented Comment Form at bottom of page
- Added a "_Show All_" tab intended to switch to the collapsible header style. Currently not functional.
- Added "_Edit_" button links to fields where I found an read-write input on another page
- Added "_View_" button links to fields where I found a read-only input on another page.
- Removed styling that highlighted fields for bugfixing, all fields now have a standard white background
- Added "_psTextWidget_" class to all custom input elements. Honestly don't know what it actually does but all the default PS fields have it so I figured I'd include it.
---
_7-6-21_
**CHANGES:**
- Removed drop-down navbar
- Added section tabs
- Added translation for NCLB field
- Formatted 'Everything Else' section to fill page space
---
**NOTES/BUGS:**
- Due to how PS loads pages; when navigating to "_Edit/View_" links the page starts at the top, even though they include id tags to focus on specific elements.
- "_Show All_" tab is empty
- Tabs besides "_Show All_" are too small
- Can't uncheck "_Show All_" box
- Page loads to "_Everything Else_" instead of "_Show All_"
- Topnav does not show up when in "_Show All_" view
- Missing "_Edit/View_" buttons for some fields
