### PR TITLE
Made sure contacts loads in correct order, fixed legal section

### DIFF
--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -3,14 +3,20 @@ $j(document).ready(function() {
   LPSGDRestyle();
   selectViewStyle();
 
-  $j( "div#LPS-GDCustomhiddentable" ).remove(); /* Remove hidden LPSGDC templates */
+  $j( "#LPS-GDCustomhiddentable" ).remove(); /* Remove hidden LPSGDC templates */
   $j( "input" ).val(function( index, value ) { return value.trim(); }); /* Remove extra whitespace from field values */
   decodeDemoVals(); /* Translate DOE Codes - 'fieldName_DOE###' (Moved to seperate function for readability) */
   
   /* Event Listeners */
   $j(window.location).on("hashchange", selectViewStyle());
+  window.setTimeout(addLegal, 3000);
 });
-
+function addLegal() {
+  $legalFields = $j("#legalLastName, #legalGenderSelect").parent().parent().addClass("row-legal");
+  $legalFields.insertAfter("#trLegal_Gender");
+  $j("#trLegal_Gender, #trLegal_FullName").remove();
+  
+}
 /* Insert custom fields & comment box into Demographics page */
 function addLPSGDFields() {
   const $trHomePhone =  $j("#fieldHomePhone").parent().parent();
@@ -27,7 +33,7 @@ function addLPSGDFields() {
       certain features.
   ============================================================================*/
   $trHomePhone.after( $j("#LPS-GDCustomhiddentable tr.row-student") ); /* Student          */
-  $trHomePhone.after( $j("#LPS-GDCustomhiddentable tr.row-contacts") ); /* Student          */
+  $trHomePhone.after( $j("#LPS-GDCustomhiddentable tr.row-contacts") );/* Contacts - Old   */
   $trHomePhone.after( $j("#demoContactsTable") );                      /* Contacts         */
   $trRaceCode.after( $j("#LPS-GDCustomhiddentable tr.row-ethRace") );  /* Ethnicity & Race */
   $trRaceCode.after( $j("#LPS-GDCustomhiddentable tr.row-office") );   /* Adminstration    */
@@ -104,25 +110,25 @@ function LPSGDRestyle() {
   
   /* Wrap Other Section */
   $j("form tr.row-other").wrapAll('<div id="OtherSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("#OtherSection").insertAfter( $j("form div#StudentSection") );
+  $j("#OtherSection").insertAfter( $j("#StudentSection") );
   /* Subsections */
   $j("form tr.row-other:first").before('<tr class="headerrow row-other"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Legal Section */
-  $j("form tr.row-legal").wrapAll('<div id="LegalSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("#LegalSection").insertAfter( $j("form div#StudentSection") );
+   $j("form tr.row-legal").wrapAll('<div id="LegalSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
+  $j("#LegalSection").insertAfter( $j("#StudentSection") );
   /* Subsections */
   $j("form tr.row-legal:first").before('<tr class="headerrow row-legal"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Grad Section */
   $j("form tr.row-grad").wrapAll('<div id="GradSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("#GradSection").insertAfter( $j("form div#StudentSection") );
+  $j("#GradSection").insertAfter( $j("#StudentSection") );
   /* Subsections */
   $j("form tr.row-grad:first").before('<tr class="headerrow row-grad"><td colspan="2" class="bold" width="100%">Information</td></tr>');
   
   /* Wrap Office Section*/
   $j("form tr.row-office").wrapAll('<div id="OfficeSection"><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("#OfficeSection").insertAfter( $j("form div#StudentSection") );
+  $j("#OfficeSection").insertAfter( $j("#StudentSection") );
   /* Subsections */
   $j("form tr.office-general:first").before('<tr class="headerrow row-office office-general"><td colspan="2" class="bold" width="100%">District Information</td></tr>');
   $j("form tr.office-el:first").before('<tr class="headerrow row-office office-el"><td colspan="2" class="bold" width="100%">EL Information</td></tr>');
@@ -131,7 +137,7 @@ function LPSGDRestyle() {
   /* Wrap Race Section */
   $j("form div#stateIncludeWrapper").wrapAll('<tr class="row-ethRace ethrace-other" width="100%"><td colspan="2"></td></tr>');
   $j("form tr.row-ethRace").wrapAll('<div id="EthRaceSection" class=""><div class="row"><table class="linkDescList" width="100%"><tbody></tbody></table></div></div>');
-  $j("#EthRaceSection").insertAfter( $j("form div#StudentSection") );
+  $j("#EthRaceSection").insertAfter( $j("#StudentSection") );
   /* Subsections */
   $j("form tr.ethrace-select:first").before('<tr class="headerrow row-ethRace ethrace-select"><td colspan="2" class="bold" width="100%">Ethnicity & Race</td></tr>');
   $j("form tr.ethrace-other:first").before('<tr class="headerrow row-ethRace ethrace-other"><td colspan="2" class="bold" width="100%">Other State General</td></tr>');
@@ -148,6 +154,9 @@ function LPSGDRestyle() {
   $j("form tr.contacts-parentsOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld"> <td colspan="2" class="bold" width="100%">Parents - Old (will be phased out)</td> </tr>');
   $j("form tr.contacts-fatherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-fatherOld"> <td colspan="2" class="bold" style="background-color:rgb(183, 201, 224)">Father - Old</td> </tr>');
   $j("form tr.contacts-motherOld:first").before('<tr class="headerrow row-contacts contacts-parentsOld contacts-motherOld"> <td colspan="2" class="bold" style="background-color:rgb(183, 201, 224)">Mother - Old</td> </tr>');
+  $j("tr.contacts-ECOld:first").before('<tr class="headerrow row-contacts contacts-ECOld"> <td colspan="2" class="bold" width="100%">Emergency Contacts - Old (will be phased out)</td> </tr>');
+  $j("form tr.contacts-EC1Old:first").before('<tr class="headerrow row-contacts ontacts-ECOld contacts-EC1Old"> <td colspan="2" class="bold" style="background-color:rgb(183, 201, 224)">Emergency Contact 1 - Old</td> </tr>');
+  $j("form tr.contacts-EC2Old:first").before('<tr class="headerrow row-contacts ontacts-ECOld contacts-EC2Old"> <td colspan="2" class="bold" style="background-color:rgb(183, 201, 224)">Emergency Contact 2 - Old</td> </tr>');
   
   /* Remove Original Table */
   $j("#StudentSection").unwrap().unwrap();
@@ -260,7 +269,7 @@ function showCollapsed() {
     if(window.pageYOffset > 50){
       $j("#demoNavBar, a.sectLink").css( {'display':'inline-block'} );
       $j("#demoNavBar").css( {'position':'fixed','top':'0','left':'0','width':'100%'} );
-      $j("a.sectLink").css( {'width':'8%'} ) //MAKE THE LINKS LOOK LIKE THEY ARE INSET, IDK HOW JUST FIGURE IT OUT!
+      $j("a.sectLink").css( {'width':'8%'} );
     } else {
       $j("#demoNavBar, a.sectLink").css( {'display':'inline-flex','width':'auto'} );
       $j("#demoNavBar").css( {'position':'initial','top':'initial'} );

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -16,7 +16,7 @@
   <nav id="demoNavBar">
     <a href="#StudentSection" class="sectLink">Student</a>
     <a href="#ContactsSection" class="sectLink">Contacts</a>
-    <a href="#EthRaceSection" class="sectLink">Ethnicity/Race</a>
+    <a href="#EthRaceSection" class="sectLink">Ethnicity & Race</a>
     <a href="#OfficeSection" class="sectLink">Administration</a>
     <a href="#GradSection" class="sectLink">Graduation</a>
     <a href="#LegalSection" class="sectLink">Legal</a>
@@ -45,11 +45,11 @@
     <!--  Custom Fields: 'Student Info' -->
       <tr id="trStudent_Mobile" class="row-student student-contactInfo">
         <td class="bold">Student Mobile &tilde;</td><!-- where is this info stored? -->
-        <td width="75%"><input type="tel" id="fieldStudentMobile" value="" placeholder="123-456-7890"  readonly /></td>
+        <td width="75%"><input type="tel" id="fieldStudentMobile" value="" placeholder="123-456-7890" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trStudent_PersonalEmail" class="row-student student-contactInfo">
         <td class="bold">Student Personal Email &tilde;</td>
-        <td width="75%"><input type="email" id="fieldPersonalEmail" value="" placeholder="student@example.com"  readonly /></td>
+        <td width="75%"><input type="email" id="fieldPersonalEmail" value="" placeholder="student@example.com" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trStudent_LPSEmail" class="row-student student-contactInfo">
         <td class="bold">Student LPS Email &tilde;</td>
@@ -62,12 +62,12 @@
             JOIN Students stu ON ssm.studentsdcid = stu.dcid
           WHERE
             stu.student_number = ~([Students]student_number)]~(email)[/tlist_sql]"
-           readonly />
+          class="psTextWidget" readonly />
         </td>
         <!--<td><button onclick="location.href='/admin/students/emailconfig.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>-->
       </tr>
-  <!-- Custom Fields: Contacts - Old -->
-      <tr style="vertical-align: bottom;" id="trContactsLivesWith" class="row-contacts contacts-guardiansOld">
+    <!-- Custom Fields: 'Contacts' -->
+    <tr style="vertical-align: bottom;" id="trContactsLivesWith" class="row-contacts contacts-guardiansOld">
         <td class="bold">Lives with</td>
         <td>
           Guardian 1: <input name="[01]guardian_lives_with" value="1" type="radio">
@@ -238,140 +238,131 @@
           <input size="5" name="[01]guardian2dayphoneext" value="" type="text" id="guardian2dayphoneext">
         </td>
       </tr>
-      <tr id="e1Info" class="row-contacts contacts-emergencyOld">
-        <td class="bold"> Emergency Contact #1</td>
-        <td>
-          <input name="[01]emerg_contact_1" type="text" id="emerg_contact_1" value="" size="25"> <b>Phone</b>
-          <input name="[01]emerg_phone_1" type="text" id="emerg_phone_1" value="" size="17" onchange="ValidatePhoneNumber('~(JSFieldParam;[01]emerg_phone_1)');">
+      <tr id="tremerg_contact_1" class="row-contacts contacts-ECOld contacts-EC1Old">
+        <td class="bold"> Emergency Contact #1 Name ~</td>
+        <td width="75%"><input name="[01]emerg_contact_1" type="text" id="emerg_contact_1" value="" size="25"></td>
+      </tr>
+      <tr id="tremerg_phone_1" class="row-contacts contacts-ECOld contacts-EC1Old">
+        <td class="bold"> Emergency Contact #1 Phone~</td>
+        <td width="75%"><input name="[01]emerg_phone_1" type="text" id="emerg_phone_1" value="" size="17" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]emerg_phone_1)');"></td>
+      </tr>
+      <tr id="tremerg_1_rel" class="row-contacts contacts-ECOld contacts-EC1Old">
+        <td class="bold"> Emergency Contact #1 Relationship~</td>
+        <td width="75%"><select name="[01]emerg_1_rel" id="emerg_1_rel">
+            <option value=" "></option>
+            <option value="Mother">Mother</option>
+            <option value="Father">Father</option>
+            <option value="Grandmother">Grandmother</option>
+            <option value="Grandfather">Grandfather</option>
+            <option value="Sibling">Sibling</option>
+            <option value="Step-Parent">Step-Parent</option>
+            <option value="Foster-Parent">Foster-Parent</option>
+            <option value="Aunt">Aunt</option>
+            <option value="Uncle">Uncle</option>
+            <option value="Cousin">Cousin</option>
+            <option value="Social Worker">Social Worker</option>
+            <option value="Legal Guardian">Legal Guardian</option>
+            <option value="Self">Self</option>
+            <option value="In-Law">In-Law</option>
+            <option value="Husband">Husband</option>
+            <option value="Wife">Wife</option>
+            <option value="Friend">Friend</option>
+            <option value="Other">Other</option>
+            </select>
         </td>
       </tr>
-      <tr id="e1Relation" class="row-contacts contacts-emergencyOld">
-        <td class="bold">Relationship</td>
-        <td colspan="3"><select name="[01]emerg_1_rel" id="emerg_1_rel">
-          <option value=" "></option>
-          <option value="Mother">Mother</option>
-          <option value="Father">Father</option>
-          <option value="Grandmother">Grandmother</option>
-          <option value="Grandfather">Grandfather</option>
-          <option value="Sibling">Sibling</option>
-          <option value="Step-Parent">Step-Parent</option>
-          <option value="Foster-Parent">Foster-Parent</option>
-          <option value="Aunt">Aunt</option>
-          <option value="Uncle">Uncle</option>
-          <option value="Cousin">Cousin</option>
-          <option value="Social Worker">Social Worker</option>
-          <option value="Legal Guardian">Legal Guardian</option>
-          <option value="Self">Self</option>
-          <option value="In-Law">In-Law</option>
-          <option value="Husband">Husband</option>
-          <option value="Wife">Wife</option>
-          <option value="Friend">Friend</option>
-          <option value="GAL">GAL</option>
-          <option value="Other">Other</option>
-        </select></td>
-      </tr>
-      <tr id="e2Info" class="row-contacts contacts-emergencyOld">
-      <td class="bold">Emergency Contact #2</td>
-      <td>
-        <input name="[01]emerg_contact_2" type="text" id="emerg_contact_2" value="" size="25"> <b>Phone</b>
-        <input name="[01]emerg_phone_2" type="text" id="emerg_phone_2" value="" size="17" onchange="ValidatePhoneNumber('~(JSFieldParam;[01]emerg_phone_2)');"></td>
-      </tr>
-      <tr id="e2Relation" class="row-contacts contacts-emergencyOld">
-        <td class="bold">&nbsp;Relationship</td>
-        <td colspan="3"><select name="[01]emerg_2_rel" id="emerg_2_rel">
-          <option value=" "></option>
-          <option value="Mother">Mother</option>
-          <option value="Father">Father</option>
-          <option value="Grandmother">Grandmother</option>
-          <option value="Grandfather">Grandfather</option>
-          <option value="Sibling">Sibling</option>
-          <option value="Step-Parent">Step-Parent</option>
-          <option value="Foster-Parent">Foster-Parent</option>
-          <option value="Aunt">Aunt</option>
-          <option value="Uncle">Uncle</option>
-          <option value="Cousin">Cousin</option>
-          <option value="Social Worker">Social Worker</option>
-          <option value="Legal Guardian">Legal Guardian</option>
-          <option value="Self">Self</option>
-          <option value="In-Law">In-Law</option>
-          <option value="Husband">Husband</option>
-          <option value="Wife">Wife</option>
-          <option value="Friend">Friend</option>
-          <option value="GAL">GAL</option>
-          <option value="Other">Other</option>
-        </select></td>
+     <tr id="tremerg_contact_2" class="row-contacts contacts-ECOld contacts-EC2Old">
+         <td class="bold"> Emergency Contact #2 Name ~</td>
+         <td width="75%"><input name="[01]emerg_contact_2" type="text" id="emerg_contact_2" value="" size="25"></td>
+     </tr>
+        <tr id="tremerg_phone_2" class="row-contacts contacts-ECOld contacts-EC2Old">
+            <td class="bold"> Emergency Contact #2 Phone~</td>
+            <td width="75%"><input name="[01]emerg_phone_2" type="text" id="emerg_phone_2" value="" size="17" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]emerg_phone_2)');"></td>
+        </tr>
+      <tr id="tremerg_2_rel" class="row-contacts contacts-ECOld contacts-EC2Old">
+        <td class="bold"> Emergency Contact #2 Relationship~</td>
+        <td width="75%"><select name="[01]emerg_2_rel" id="emerg_2_rel">
+            <option value=" "></option>
+            <option value="Mother">Mother</option>
+            <option value="Father">Father</option>
+            <option value="Grandmother">Grandmother</option>
+            <option value="Grandfather">Grandfather</option>
+            <option value="Sibling">Sibling</option>
+            <option value="Step-Parent">Step-Parent</option>
+            <option value="Foster-Parent">Foster-Parent</option>
+            <option value="Aunt">Aunt</option>
+            <option value="Uncle">Uncle</option>
+            <option value="Cousin">Cousin</option>
+            <option value="Social Worker">Social Worker</option>
+            <option value="Legal Guardian">Legal Guardian</option>
+            <option value="Self">Self</option>
+            <option value="In-Law">In-Law</option>
+            <option value="Husband">Husband</option>
+            <option value="Wife">Wife</option>
+            <option value="Friend">Friend</option>
+            <option value="Other">Other</option>
+            </select>
+        </td>
       </tr>
     <!--  Custom Fields: 'Ethnicity & Race Info' -->
-      <tr id="trRace_ExcludeState" class="row-ethRace ethrace-other">
-        <td class="bold">Exclude from State Reporting? &tilde;</td>
-        <td><input type="text" name="[Students]State_ExcludeFromReporting" id="fieldExcludeState" value="~(State_ExcludeFromReporting)"  readonly /></td>
-      </tr>
-      <tr id="trRace_IncludeSIMS" class="row-ethRace ethrace-other">
-        <td class="bold">Include in SIMS Report? &tilde;</td>
-        <td><input type="text" name="[Students.S_MA_STU_SIMS_X]IncludeInSIMSInd" id="fieldIncludeSIMS" value="~(IncludeInSIMSInd)"  readonly /></td>
-      </tr>
-      <tr id="trRace_IncludeSASID" class="row-ethRace ethrace-other">
-        <td class="bold">Include in SASID Report? &tilde;</td>
-        <td><input type="text" name="[Students.S_MA_STU_X]IncludeInSASIDMSRInd" id="fieldIncludeSASID" value="~(IncludeInSASIDMSRInd)"  readonly /></td>
-      </tr>
       <tr id="trRace_BirthCity" class="row-ethRace ethrace-other"> <!-- DOE008 *Must be converted to town code -->
         <td class="bold">City/Town of Birth &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]BirthCity" id="fieldBirthCity" value="~(BirthCity)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trRace_Military" class="row-ethRace ethrace-other"> <!-- DOE029 -->
         <td class="bold">Family Military Status &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]MilitaryStatus" id="fieldMilitaryStatus" value="~(MilitaryStatus)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]MilitaryStatus" id="fieldMilitaryStatus" value="~(MilitaryStatus)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#militaryStatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
     <!--  Custom Fields: 'Office Data' -->
       <tr id="trOffice_EntryDate" class="row-office office-general">
         <td class="bold">District Entry Date &tilde;</td>
-        <td width="75%"><input type="text" name="[Students]DistrictEntryDate" id="fieldEntryDate" value="~(DistrictEntryDate)" placeholder="~[short.date]"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students]DistrictEntryDate" id="fieldEntryDate" value="~(DistrictEntryDate)" placeholder="~[short.date]" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/modifydata.html?frn=~(frn)#dp1626705387672" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOffice_EntryGrade" class="row-office office-general">
         <td class="bold">District Entry Grade &tilde;</td> <!-- Auto-formatting makes this want a number, so translating it to K/PK might cause issues?   -->
-        <td width="75%"><input type="text" name="[Students]DistrictEntryGradeLevel" id="fieldEntryGrade" value="~(DistrictEntryGradeLevel)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students]DistrictEntryGradeLevel" id="fieldEntryGrade" value="~(DistrictEntryGradeLevel)" class="psTextWidget" readonly /></td>
         <!-- Entry Grade has no ID to link to on target page so linking to Entry Date which is directly above it -->
         <!--<td><button onclick="location.href='/admin/students/modifydata.html?frn=~(frn)#dp1626705387672" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOffice_SchoolCode" class="row-office office-general">
         <td class="bold">School Code &tilde;</td> <!-- DOE015 *code = 0000000[1,2] for SPED (1:gradeLvl >12 or private preschool), (2:homeschooled) -->
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]OverrideSchoolCode" id="fieldSchoolCode" value="~(OverrideSchoolCode)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]OverrideSchoolCode" id="fieldSchoolCode" value="~(OverrideSchoolCode)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_SchoolCode'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOffice_ELCode" class="row-office office-el"> <!-- DOE027 or 24? maybe 41? -->
         <td class="bold">EL Code &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]EL" id="fieldELCode" value="~(EL)" placeholder="EL CODE ###..."  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]EL" id="fieldELCode" value="~(EL)" placeholder="EL CODE ###..." class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/ellsims.html?frn=~(frn)'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOffice_FLEPDate" class="row-office office-el">
         <td class="bold">FLEP Date &tilde;</td> <!-- BUG: For some reason '~[short.date]' returns 'MM/DD/YYYY' here but gives the actual date in #fieldGradDate (I think because gradDate is a custom value) -->
-        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]FLEPDate" id="fieldFLEPDate" value="~(FLEPDate)" placeholder="~[short.date]"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]FLEPDate" id="fieldFLEPDate" value="~(FLEPDate)" placeholder="~[short.date]" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trOffice_SPEDCode" class="row-office office-sped"> <!-- -->
         <td class="bold">SPED Code &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_Students_Extension]SPED" id="fieldSPEDCode" value="~(SPED)" placeholder="SPED CODE ###..."  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Students_Extension]SPED" id="fieldSPEDCode" value="~(SPED)" placeholder="SPED CODE ###..." class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/spe.html?frn=~(frn)'" class="editButton" type="button">View</button></td>-->
       </tr>
       <tr id="trOffice_504Plan" class="row-office office-sped">
         <td class="bold">504 Plan &tilde;</td> <!-- DOE039-->
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_SPED_X]Sec504PlanStatus" id="field504Plan" value="~(Sec504PlanStatus)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_SPED_X]Sec504PlanStatus" id="field504Plan" value="~(Sec504PlanStatus)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_504PlanStatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
     <!--  Custom Fields: 'Graduation Info' -->
       <tr id="trGrad_Date" class="row-grad">
         <td class="bold">Graduation Date &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]Grad_Date" id="fieldGradDate" value="~(Grad_Date)" placeholder="~[short.date]"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]Grad_Date" id="fieldGradDate" value="~(Grad_Date)" placeholder="~[short.date]" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trGrad_Cohort" class="row-grad">
         <td class="bold">DESE Cohort &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]cohort" id="fieldCohort" value="~(cohort)" placeholder="COHORT #..."  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]cohort" id="fieldCohort" value="~(cohort)" placeholder="COHORT #..." class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trGrad_Plan" class="row-grad"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
         <td class="bold">Post-Graduation Plan &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]PostGradPlans" id="fieldGradPlan" value="~(PostGradPlans)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]PostGradPlans" id="fieldGradPlan" value="~(PostGradPlans)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#futureplans'" class="editButton" type="button">Edit</button></td>-->
          <!-- DEPENDENCIES: If...
               ...DOE012(Enrollment) = '04'(Graduate), then DOE033 != '500'(N/A) and DOE037(Core Completion) != '00'(Not a graduate)
@@ -379,10 +370,10 @@
       </tr>
       <tr id="trGrad_CoreCompletion" class="row-grad"> <!-- DOE037 *DOE033(GradPlan) dependencies includes all DOE037 dependencies  -->
         <td class="bold">Massachusetts Core Curriculum Completion &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]GradCompleteCoreCurriculum" id="fieldCoreCompletion" value="~(GradCompleteCoreCurriculum)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]GradCompleteCoreCurriculum" id="fieldCoreCompletion" value="~(GradCompleteCoreCurriculum)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#gradstatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
-    <!-- Custom Fields: 'Legal Info' -->
+      <!-- Custom Fields: 'Legal Info' -->
       <tr id="trLegal_FullName" class="row-legal">
         <td class="bold">Legal Name (Last, First Middle Suffix) &tilde;</td>
         <td width="75%">
@@ -402,55 +393,56 @@
     <!-- Custom Fields: 'Other' (LPS)  -->
       <tr id="trOther_NCLB" class="row-other other-lps"> <!-- DOE020(?) *DOE020 is for 'Title 1 participation type', this is 'Title 1 School Choice status'. Don't know what the difference is. -->
         <td class="bold">NCLB/Title 1 School Choice &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_SIMS_X]Title1SchoolChoice" id="fieldNCLB" value="~(Title1SchoolChoice)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_SIMS_X]Title1SchoolChoice" id="fieldNCLB" value="~(Title1SchoolChoice)" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trOther_FirstYearEL" class="row-other other-lps"> <!-- DOE021 *DEPENDENCIES: Students with Grade Level(DOE016) = 'PK' or 'SP' should be given '00'(N/A)-->
         <td class="bold">First Year English Learner &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEP1stYrInUS" id="fieldFirstYearEL" value="~(LEP1stYrInUS)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEP1stYrInUS" id="fieldFirstYearEL" value="~(LEP1stYrInUS)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_LEPinUS'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_IsEL" class="row-other other-lps"> <!-- DOE025 *DEPENDENCIES: If DOE025 = '01'(yes_EL) then DOE024(Native Language) != '267'(English) -->
         <td class="bold">English Learner &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency" id="fieldIsEL" value="~(LimitedEnglishProficiency)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LimitedEnglishProficiency" id="fieldIsEL" value="~(LimitedEnglishProficiency)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_EngProficiency'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_ELStatus" class="row-other other-lps"> <!-- DOE026 *DEPENDENCIES: If DOE026 != '00'(Not Enrolled) then DOE025(isEL) = '01'(yes_EL)-->
         <td class="bold">EL Program Status &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEPProgramStatus" id="fieldELStatus" value="~(LEPProgramStatus)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]LEPProgramStatus" id="fieldELStatus" value="~(LEPProgramStatus)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#BilingualStatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_SASID" class="row-other other-lps"> <!-- DOE002 *10 digits long, -->
         <td class="bold">State Assigned Student Identifier (SASID) &tilde;</td>
-        <td width="75%"><input type="text" name="[Students]State_StudentNumber" id="fieldSASID" value="~(State_StudentNumber)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students]State_StudentNumber" id="fieldSASID" value="~(State_StudentNumber)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#ldv_generatedID2'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_IsImmigrant" class="row-other other-lps"> <!-- DOE022 *DEPENDENCIES: If DOE022 = '01'(yes_immigrant) then DOE023(Origin Country) != '500'(not an immigrant) -->
         <td class="bold">Immigrant &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]ImmigrantStatus" id="fieldImmigrantStatus" value="~(ImmigrantStatus)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]ImmigrantStatus" id="fieldImmigrantStatus" value="~(ImmigrantStatus)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_ImmgrStatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_EnrollmentStatus" class="row-other other-lps"> <!-- DOE012 *DEPENDENCIES: Students reported with a code of 04 must be in grades 11, 12 or SP. See DOE033/Appendix I(in doc) for more -->
         <td class="bold">Enrollment Status &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]EnrollStatusTimeOfCollection" id="fieldEnrollmentStatus" value="~(EnrollStatusTimeOfCollection)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_X]EnrollStatusTimeOfCollection" id="fieldEnrollmentStatus" value="~(EnrollStatusTimeOfCollection)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#enrollstatus'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_TransferFrom" class="row-other other-lps">
         <td class="bold">Transferring from &tilde;</td>
-        <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME"  readonly /></td>
+        <td width="75%"><input type="text" id="fieldTransferFrom" value="" size="17" placeholder="SCHOOL NAME" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trOther_BirthState" class="row-other other-lps">
         <td class="bold">Birth State &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]MA_BirthState" id="fieldBirthState" value="~(MA_BirthState)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]MA_BirthState" id="fieldBirthState" value="~(MA_BirthState)" class="psTextWidget" readonly /></td>
       </tr>
       <tr id="trOther_OriginCountry" class="row-other other-lps"> <!-- DOE023 *Surely there's a better way to do this than list every country here -->
         <td class="bold">Country of Origin &tilde;</td> <!-- value="500" > not an immigrant student (US Origin) -->
-        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]CountryOfOrigin" id="fieldOriginCountry" value="~(CountryOfOrigin)"  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.S_MA_STU_Demographic_X]CountryOfOrigin" id="fieldOriginCountry" value="~(CountryOfOrigin)" class="psTextWidget" readonly /></td>
         <!--<td><button onclick="location.href='/admin/students/state/USA_MA/stateMA-SIMS.html?frn=~(frn)#MA_Country'" class="editButton" type="button">Edit</button></td>-->
       </tr>
       <tr id="trOther_TeamFlag" class="row-other other-lps">
         <td class="bold">Team Flag &tilde;</td>
-        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]TeamFlag" id="fieldTeamFlag" value="~(TeamFlag)"  placeholder="TEAM FLAG..."  readonly /></td>
+        <td width="75%"><input type="text" name="[Students.U_StudentsUserFields]TeamFlag" id="fieldTeamFlag" value="~(TeamFlag)"  placeholder="TEAM FLAG..." class="psTextWidget" readonly /></td>
       </tr>
+      
     </tbody>
   </table>
       
@@ -622,7 +614,7 @@
       </table>
       <!--============================================|STUDENT_CONTACTS_TABLE_END|============================================-->
     </div>
-    <script> var _curSchoolNumber = 0; </script>
+    <script>  var _curSchoolNumber = ~(curschoolid); </script>
     <div class="hidden">
       <input id="studentDcid" type="hidden" value="~(rn)" />
       <input id="schoolId" type="hidden" value="~(OverrideSchoolCode)" />
@@ -632,20 +624,20 @@
 
   <!-- Comment Form -->
   <div class="box-round" id="demoComments">
-    ~[tlist_child:STUDENTS.U_COMMENT.U_COMMENT;displaycols:COMMENT_DATE,COMMENT_REASON,COMMENT_PERSON,COMMENT_COMMENT;fieldNames:Date of Comment,Reason for Comment,Person Making Change,Comment;type:html]
-    <script>
-      var InstValues= {};
-      InstValues[' ']='';
-      InstValues['REG']='Registration';
-      InstValues['COA']='Change of Address';
-      InstValues['PCU']='Program Code Updates';
-      InstValues['HOME']='Homeless';
-      InstValues['TF']='TransferFrom-Original';
-      InstValues['WD']='Withdrawal';
-      InstValues['GC']='Grade Change';
-      InstValues['RE']='Re-Engaged';
-      InstValues['Other']='Other';
-      tlistText2DropDown('COMMENT_REASON',InstValues);
+     ~[tlist_child:STUDENTS.U_COMMENT.U_COMMENT;displaycols:COMMENT_DATE,COMMENT_REASON,COMMENT_PERSON,COMMENT_COMMENT;fieldNames:Date of Comment,Reason for Comment,Person Making Change,Comment;type:html]
+    <script type="text/javascript">
+        var InstValues= [];
+        InstValues.push([' ','']);
+        InstValues.push(['REG','Registration']);
+        InstValues.push(['COA','Change of Address']);
+        InstValues.push(['PCU','Program Code Updates']);
+        InstValues.push(['HOME','Homeless']);
+        InstValues.push(['TF','TransferFrom-Original']);
+        InstValues.push(['WD','Withdrawal']);
+        InstValues.push(['GC','Grade Change']);
+        InstValues.push(['RE','Re-Engaged']);
+        InstValues.push(['Other','Other']);
+        tlistText2DropDownValNamePair('COMMENT_REASON',InstValues);
     </script>
         <!-- <div class="button-row"><input type="hidden" name="ac" value="prim">~[submitbutton]</div> -->
     </div>

--- a/WEB_ROOT/admin/styles/LPSGDC.css
+++ b/WEB_ROOT/admin/styles/LPSGDC.css
@@ -1,3 +1,6 @@
+#pds-header {
+  background-color: #00427c !important; /* Testing w/ main PS Site header color */
+}
 #pds-header > header {
   flex: 1 0 25% !important;
 }


### PR DESCRIPTION
Removed `insert("tr.ECOld")` as the row-contacts grab does that job already, and moved contacts to the correct location in the hidden table for code clarity

Legal Field now creates a temporary version and then replaces it with the fields that are added to the page after it loads.