### PR TITLE
Updated collapsible headers

### DIFF
--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -172,13 +172,6 @@ function makeCollapsible() {
   $j("form div.row").parent().css("margin", "0 11px 0 11px");
   $j("form div.row").css("margin", "0");
 
-  /* Sections start collapsed */
-  // $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
-  //   hideCollapseClasses($j(this));
-  //   hideCollapseText($j(this));
-  //   hideCollapseTarget($j(this));
-  // });
-
   /* Navbar Event Listeners */
   $j(".sectLink").on('click', function(event) {
     /* Check for hash(anchor link) value NOTE: this.hash returns part of URL beginning with '#' aka the id of the linked element */
@@ -233,7 +226,7 @@ function makeCollapsible() {
 }
 
 
-/* Decode DOE fields + fields w/ ambiguous values */
+/* Decode DOE fields + fields w/ ambiguous values ~ DEPRECATED (breaks form validation) */
 // function decodeDemoVals() {
 //   var $enrollmentStatus_012 = $j("#fieldEnrollmentStatus");
 //   var $firstYearEL_021 = $j("#fieldFirstYearEL");

--- a/WEB_ROOT/admin/javascript/LPSGDC.js
+++ b/WEB_ROOT/admin/javascript/LPSGDC.js
@@ -158,7 +158,7 @@ function LPSGDRestyle() {
 /* Add collapsible headers + activate navBar */
 function makeCollapsible() {
 
-  const createCollapseHeader = (title) => { return '<h2 class="toggle expanded collapseHeader" title="Click here to expand or collapse">' + title + ' <small>(Click to Expand/Collapse)</small></h2>' };
+  const createCollapseHeader = (title) => { return '<h2 pss-expand-collapse-item="Section" class="collapsed" title="Click here to expand or collapse">' + title + ' <small>(Click to Expand/Collapse)</small></h2>' };
 
   $j("#StudentSection").before( createCollapseHeader("Student Information") );
   $j("#OtherSection").before( createCollapseHeader("Other") );
@@ -173,11 +173,11 @@ function makeCollapsible() {
   $j("form div.row").css("margin", "0");
 
   /* Sections start collapsed */
-  $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
-    hideCollapseClasses($j(this));
-    hideCollapseText($j(this));
-    hideCollapseTarget($j(this));
-  });
+  // $j('form > div.box-round > table.linkDescList > tbody > h2').each(function() {
+  //   hideCollapseClasses($j(this));
+  //   hideCollapseText($j(this));
+  //   hideCollapseTarget($j(this));
+  // });
 
   /* Navbar Event Listeners */
   $j(".sectLink").on('click', function(event) {

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -346,7 +346,7 @@
       </tr>
       <tr id="trGrad_Cohort" class="row-grad">
         <td class="bold">DESE Cohort </td>
-        <td width="75%"><input type="text" name="[Students.U_Def_Ext_Students]cohort" id="fieldCohort" value="~(cohort)" placeholder="COHORT #..."/></td>
+        <td width="75%"><input type="text" name="[Students.U_Students_Extension]cohort" id="fieldCohort" value="~(cohort)" placeholder="COHORT #..."/></td>
       </tr>
       <tr id="trGrad_Plan" class="row-grad"> <!-- DOE033 *PK-10 = '500', 11/12 = '500' until graduated/receive certificate/complete grade 12 -->
         <td class="bold">Post-Graduation Plan </td>

--- a/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
+++ b/WEB_ROOT/admin/students/generaldemographics.LPSGDC.content.footer.txt
@@ -42,11 +42,11 @@
       </tr>
       <tr id="trStudent_Mobile" class="row-student student-contactInfo">
         <td class="bold">Student Mobile</td><!-- where is this info stored? -->
-        <td width="75%"><input type="tel" id="fieldStudentMobile" name="[U_Students_Extension]student_mobile" value="~(student_mobile)" placeholder="123-456-7890"/></td>
+        <td width="75%"><input type="tel" id="fieldStudentMobile" name="[Students.U_Students_Extension]student_mobile" value="~(student_mobile)" placeholder="123-456-7890"/></td>
       </tr>
       <tr id="trStudent_PersonalEmail" class="row-student student-contactInfo">
         <td class="bold">Student Personal Email </td>
-        <td width="75%"><input type="email" id="fieldPersonalEmail" name="[U_Students_Extension]STUDENT_PERSONALEMAIL" value="~(STUDENT_PERSONALEMAIL)" placeholder="student@example.com"/></td>
+        <td width="75%"><input type="email" id="fieldPersonalEmail" name="[Students.U_Students_Extension]STUDENT_PERSONALEMAIL" value="~(STUDENT_PERSONALEMAIL)" placeholder="student@example.com"/></td>
       </tr>
       <tr id="trStudent_LPSEmail" class="row-student student-contactInfo">
         <td class="bold">Student LPS Email </td>
@@ -66,8 +66,8 @@
     <tr style="vertical-align: bottom;" id="trContactsLivesWith" class="row-contacts contacts-guardiansOld">
         <td class="bold">Lives with</td>
         <td>
-          Guardian 1: <input name="[01]guardian_lives_with" value="1" type="radio">
-          Guardian 2: <input name="[01]guardian_lives_with" value="2" type="radio">
+          Guardian 1: <input name="[Students]guardian_lives_with" value="1" type="radio">
+          Guardian 2: <input name="[Students]guardian_lives_with" value="2" type="radio">
         </td>
       </tr>
       <tr style="vertical-align: top;" id="g1Header" class="row-contacts contacts-guardiansOld contacts-guardian1">
@@ -75,7 +75,7 @@
       </tr>
       <tr id="g1Relation" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td class="bold">Relationship</td>
-        <td><select name="[01]guardian_relationship" id="guardian_relationship" >
+        <td><select name="[Students]guardian_relationship" id="guardian_relationship" >
           <option value=" "></option>
           <option value="Mother">Mother</option>
           <option value="Father">Father</option>
@@ -101,7 +101,7 @@
       <tr id="g1FullName" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td class="bold">Last Name, First Name</td>
         <td>
-          <select name="[01]guardian_title" id="guardian_title">
+          <select name="[Students]guardian_title" id="guardian_title">
             <option value=""></option>
             <option value="Ms">Ms</option>
             <option value="Mrs">Mrs</option>
@@ -109,48 +109,48 @@
             <option value="Mr">Mr</option>
             <option value="Dr">Dr</option>
           </select>
-          <input name="[01]guardian_LN" id="guardian_LN" value="" type="text" >
-          <input name="[01]guardian_FN" id="guardian_FN" value="" type="text" >
+          <input name="[Students]guardian_LN" id="guardian_LN" value="" type="text" >
+          <input name="[Students]guardian_FN" id="guardian_FN" value="" type="text" >
         </td>
       </tr>
       <tr id="g1Address" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td class="bold">Address</td>
-        <td><input size="30" name="[01]guardianstreet" id="guardianstreet" value="" type="text" ></td>
+        <td><input size="30" name="[Students]guardianstreet" id="guardianstreet" value="" type="text" ></td>
       </tr>
       <tr id="g1CopyAddr" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td></td>
         <td>
-          <input name="[01]guardiancity" id="guardiancity" size="15" value="" type="text" >
-          <input maxlength="2" name="[01]guardianstate" id="guardianstate" size="2" value="" type="text" >
-          <input name="[01]guardianzip" value="" id="guardianzip" size="10" type="text" >
+          <input name="[Students]guardiancity" id="guardiancity" size="15" value="" type="text" >
+          <input maxlength="2" name="[Students]guardianstate" id="guardianstate" size="2" value="" type="text" >
+          <input name="[Students]guardianzip" value="" id="guardianzip" size="10" type="text" >
         </td>
       </tr>
       <tr id="g1HomePhone" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td class="bold">Home Phone </td>
-        <td><input name="[01]guardianhomephone" value="" id="guardianhomephone" type="text" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardianhomephone)');" ></td>
+        <td><input name="[Students]guardianhomephone" value="" id="guardianhomephone" type="text" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardianhomephone)');" ></td>
       </tr>
       <tr id="g1CellPhone" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td class="bold">Cell Phone </td>
-        <td><input name="[01]guardian_cell_phone" value="" id="guardian_cell_phone" type="text" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardian_cell_phone)');" ></td>
+        <td><input name="[Students]guardian_cell_phone" value="" id="guardian_cell_phone" type="text" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardian_cell_phone)');" ></td>
       </tr>
       <tr id="g1Email" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td class="bold">Email</td>
-        <td><input name="[01]guardianemail" value="" size="30" id="guardianemail" type="text" ></td>
+        <td><input name="[Students]guardianemail" value="" size="30" id="guardianemail" type="text" ></td>
       </tr>
       <tr id="g1Employe" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td class="bold">Employer</td>
-        <td> <input size="30" name="[01]guardian_employer" value="" id="guardian_employer" type="text" > </td>
+        <td> <input size="30" name="[Students]guardian_employer" value="" id="guardian_employer" type="text" > </td>
       </tr>
       <tr id="g1Occupation" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td class="bold">Occupation</td>
-        <td><input size="30" name="[01]guardian_occupation" id="guardian_occupation" value="" type="text" ></td>
+        <td><input size="30" name="[Students]guardian_occupation" id="guardian_occupation" value="" type="text" ></td>
       </tr>
       <tr id="g1DayPhone" class="row-contacts contacts-guardiansOld contacts-guardian1">
         <td class="bold">Day Phone</td>
         <td class="bold">
-          <input name="[01]guardiandayphone" value="" type="text" id="guardiandayphone" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardiandayphone)');" >
+          <input name="[Students]guardiandayphone" value="" type="text" id="guardiandayphone" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardiandayphone)');" >
           Ext.
-          <input size="5" name="[01]guardiandayphoneext" value="" type="text" id="guardiandayphoneext" >
+          <input size="5" name="[Students]guardiandayphoneext" value="" type="text" id="guardiandayphoneext" >
         </td>
       </tr>
       <tr style="vertical-align: top;" id="g2Header" class="row-contacts contacts-guardiansOld contacts-guardian2">
@@ -158,7 +158,7 @@
       </tr>
       <tr id="g2Relation" class="row-contacts contacts-guardiansOld contacts-guardian2">
         <td class="bold">Relationship</td>
-        <td><select name="[01]guardian2_relationship" id="guardian2_relationship">
+        <td><select name="[Students]guardian2_relationship" id="guardian2_relationship">
           <option value=" "></option>
           <option value="Mother">Mother</option>
           <option value="Father">Father</option>
@@ -183,7 +183,7 @@
       </tr>
       <tr id="g2FullName" class="row-contacts contacts-guardiansOld contacts-guardian2">
         <td class="bold">Last Name, First Name</td>
-        <td><select name="[01]guardian2_title" id="guardian2_title">
+        <td><select name="[Students]guardian2_title" id="guardian2_title">
           <option value=""></option>
           <option value="Ms">Ms</option>
           <option value="Mrs">Mrs</option>
@@ -191,60 +191,60 @@
           <option value="Mr">Mr</option>
           <option value="Dr">Dr</option>
         </select>
-        <input name="[01]guardian2_LN" id="guardian2_LN" type="text" value=""> <input name="[01]guardian2_FN" id="guardian2_FN" type="text" value="" >
+        <input name="[Students]guardian2_LN" id="guardian2_LN" type="text" value=""> <input name="[Students]guardian2_FN" id="guardian2_FN" type="text" value="" >
         </td>
       </tr>
       <tr id="g2Address" class="row-contacts contacts-guardiansOld contacts-guardian2">
         <td class="bold">Address</td>
-        <td><input size="30" name="[01]guardian2street" id="guardian2street" value="" type="text" ></td>
+        <td><input size="30" name="[Students]guardian2street" id="guardian2street" value="" type="text" ></td>
       </tr>
       <tr id="g2CopyAddr" class="row-contacts contacts-guardiansOld contacts-guardian2">
         <td></td>
         <td>
-          <input name="[01]guardian2city" value="" id="guardian2city" size="15" type="text" >
-          <input maxlength="2" name="[01]guardian2state" value="" id="guardian2state" size="2" type="text" >
-          <input name="[01]guardian2zip" value="" id="guardian2zip" size="10" type="text" >
+          <input name="[Students]guardian2city" value="" id="guardian2city" size="15" type="text" >
+          <input maxlength="2" name="[Students]guardian2state" value="" id="guardian2state" size="2" type="text" >
+          <input name="[Students]guardian2zip" value="" id="guardian2zip" size="10" type="text" >
         </td>
       </tr>
       <tr id="g2HomePhone" class="row-contacts contacts-guardiansOld contacts-guardian2">
         <td class="bold">Home Phone </td>
-        <td><input name="[01]guardian2homephone" value="" id="guardian2homephone" type="text" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardian2homephone)');" ></td>
+        <td><input name="[Students]guardian2homephone" value="" id="guardian2homephone" type="text" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardian2homephone)');" ></td>
       </tr>
       <tr id="g2CellPhone" class="row-contacts contacts-guardiansOld contacts-guardian2">
         <td class="bold">Cell Phone </td>
-        <td><input name="[01]guardian2_cell_phone" value="" id="guardian2_cell_phone" type="text" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardian2_cell_phone)');" ></td>
+        <td><input name="[Students]guardian2_cell_phone" value="" id="guardian2_cell_phone" type="text" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardian2_cell_phone)');" ></td>
       </tr>
       <tr id="g2Email" class="row-contacts contacts-guardiansOld contacts-guardian2">
         <td class="bold">Email</td>
-        <td><input name="[01]guardian2email" value="" id="guardian2email" size="30" type="text" ></td>
+        <td><input name="[Students]guardian2email" value="" id="guardian2email" size="30" type="text" ></td>
       </tr>
       <tr id="g2Employer" class="row-contacts contacts-guardiansOld contacts-guardian2">
         <td class="bold">Employer</td>
-        <td><input size="30" name="[01]guardian2_employer" value="" id="guardian2_employer" type="text" ></td>
+        <td><input size="30" name="[Students]guardian2_employer" value="" id="guardian2_employer" type="text" ></td>
       </tr>
       <tr id="g2Occupation" class="row-contacts contacts-guardiansOld contacts-guardian2">
           <td class="bold">Occupation</td>
-          <td><input size="30" name="[01]guardian2_occupation" id="[01]guardian2_occupation" value="" type="text" ></td>
+          <td><input size="30" name="[Students]guardian2_occupation" id="[01]guardian2_occupation" value="" type="text" ></td>
       </tr>
       <tr id="g2DayPhone" class="row-contacts contacts-guardiansOld contacts-guardian2">
         <td class="bold">Day Phone</td>
         <td class="bold">
-          <input name="[01]guardian2dayphone" value="" type="text" id="guardian2dayphone" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardian2dayphone)');" >
+          <input name="[Students]guardian2dayphone" value="" type="text" id="guardian2dayphone" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]guardian2dayphone)');" >
            Ext.
-          <input size="5" name="[01]guardian2dayphoneext" value="" type="text" id="guardian2dayphoneext" >
+          <input size="5" name="[Students]guardian2dayphoneext" value="" type="text" id="guardian2dayphoneext" >
         </td>
       </tr>
       <tr id="tremerg_contact_1" class="row-contacts contacts-ECOld contacts-EC1Old">
         <td class="bold">Contact's Name</td>
-        <td width="75%"><input name="[01]emerg_contact_1" type="text" id="emerg_contact_1" value="" size="25" ></td>
+        <td width="75%"><input name="[Students]emerg_contact_1" type="text" id="emerg_contact_1" value="" size="25" ></td>
       </tr>
       <tr id="tremerg_phone_1" class="row-contacts contacts-ECOld contacts-EC1Old">
         <td class="bold">Contact's Phone</td>
-        <td width="75%"><input name="[01]emerg_phone_1" type="text" id="emerg_phone_1" value="" size="17" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]emerg_phone_1)');" ></td>
+        <td width="75%"><input name="[Students]emerg_phone_1" type="text" id="emerg_phone_1" value="" size="17" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]emerg_phone_1)');" ></td>
       </tr>
       <tr id="tremerg_1_rel" class="row-contacts contacts-ECOld contacts-EC1Old">
         <td class="bold">Relation to Student</td>
-        <td width="75%"><select name="[01]emerg_1_rel" id="emerg_1_rel">
+        <td width="75%"><select name="[Students]emerg_1_rel" id="emerg_1_rel">
             <option value=" "></option>
             <option value="Mother">Mother</option>
             <option value="Father">Father</option>
@@ -269,15 +269,15 @@
       </tr>
      <tr id="tremerg_contact_2" class="row-contacts contacts-ECOld contacts-EC2Old">
          <td class="bold">Contact's Name</td>
-         <td width="75%"><input name="[01]emerg_contact_2" type="text" id="emerg_contact_2" value="" size="25" ></td>
+         <td width="75%"><input name="[Students]emerg_contact_2" type="text" id="emerg_contact_2" value="" size="25" ></td>
      </tr>
         <tr id="tremerg_phone_2" class="row-contacts contacts-ECOld contacts-EC2Old">
             <td class="bold">Contact's Phone</td>
-            <td width="75%"><input name="[01]emerg_phone_2" type="text" id="emerg_phone_2" value="" size="17" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]emerg_phone_2)');" ></td>
+            <td width="75%"><input name="[Students]emerg_phone_2" type="text" id="emerg_phone_2" value="" size="17" onChange="ValidatePhoneNumber('~(JSFieldParam;[01]emerg_phone_2)');" ></td>
         </tr>
       <tr id="tremerg_2_rel" class="row-contacts contacts-ECOld contacts-EC2Old">
         <td class="bold">Relation to Student</td>
-        <td width="75%"><select name="[01]emerg_2_rel" id="emerg_2_rel">
+        <td width="75%"><select name="[Students]emerg_2_rel" id="emerg_2_rel">
             <option value=" "></option>
             <option value="Mother">Mother</option>
             <option value="Father">Father</option>


### PR DESCRIPTION
headers are now created using `<h2 pss-expand-collapse-item="Section" class="collapsed">. . .</h2>`
- removes need to manually collapse headers after creation
- prevents page from resizing after rendering due to headers collapsing

NOTE: created an expand-collapse-item key, but decided not to replace the current "collapse/expand all" buttons as they are working/styled properly already